### PR TITLE
fix(backup): scheduled backup 找不到 rclone.conf 致每日失败

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ ENV APP_ENV=production \
     DATABASE_URL=sqlite:////data/beecount.db \
     BACKUP_STORAGE_DIR=/data/backups \
     ATTACHMENT_STORAGE_DIR=/data/attachments \
+    RCLONE_CONFIG_PATH=/data/rclone.conf \
     WEB_STATIC_DIR=/app/static \
     ALLOW_APP_RW_SCOPES=true \
     APP_VERSION=${VERSION}

--- a/src/config.py
+++ b/src/config.py
@@ -34,9 +34,16 @@ class Settings(BaseSettings):
     attachment_max_upload_bytes: int = 64 * 1024 * 1024
 
     # ===== rclone 备份模块 =====
-    # rclone.conf 路径(权限 0600,只 server 进程读写)。默认放在 DATA_DIR
-    # 同级,跟 backup volume 一起被备份覆盖外部脚本时也能保留。
-    rclone_config_path: str = "./data/rclone.conf"
+    # rclone.conf 路径(权限 0600,只 server 进程读写)。默认 `./data/rclone.conf`
+    # 配合本地开发(WORKDIR 平级 ./data)。**生产 Docker 镜像必须通过
+    # `RCLONE_CONFIG_PATH=/data/rclone.conf` env 覆盖**,跟 BACKUP_STORAGE_DIR /
+    # ATTACHMENT_STORAGE_DIR 一样落到 mounted volume 持久化。
+    # 没 alias 的话 Dockerfile 改 env 不生效 — 容器 WORKDIR /app 下 ./data 是
+    # docs-index COPY 来的临时层,容器重建就丢 rclone.conf,scheduled backup
+    # 找不到 conf 直接 fail(2026-05-14 线上事故)。
+    rclone_config_path: str = Field(
+        default="./data/rclone.conf", alias="RCLONE_CONFIG_PATH"
+    )
     # rclone 二进制路径,Docker 镜像里 apt 装的会在 /usr/bin/rclone。
     rclone_binary: str = "rclone"
     # 备份打包 + 还原解压的临时区。需要 ≥ 2x DATA_DIR 大小。

--- a/src/services/backup/runner.py
+++ b/src/services/backup/runner.py
@@ -318,6 +318,15 @@ def _run_with_remotes(
             tar_path = None  # type: ignore[assignment]
 
         # ---- 6. fan-out push ----
+        # 确保 rclone.conf 反映 DB 里最新 remote 配置 —— manual run-now 路径在
+        # routers/admin_backup.py:507 已有同样调用,scheduled backup 历史上漏了
+        # 这步,容器重建 / conf 文件丢失就直接 fail(2026-05-14 线上事故就是
+        # 这条路径触发的)。每次 backup 前重写一次保证自愈。
+        config_mgr = RcloneConfigManager(
+            settings.rclone_config_path, settings.rclone_binary
+        )
+        config_mgr.rewrite_from_db(db, user_id)
+
         runner = RcloneRunner(
             binary=settings.rclone_binary,
             config_path=settings.rclone_config_path,


### PR DESCRIPTION
## Summary

线上备份从 **2026-05-14** 起每天 04:00 scheduled backup 全部 failed,错误:
```
{"level":"warning","msg":"Config file \"/app/data/rclone.conf\" not found - using defaults"}
Failed to create file system for destination "s3-backup:beecount-backup/":
  didn't find section in config file
```

时间线吻合 1.2.0 (commit 2e6f903) 在 2026-05-13 20:49 merge 后部署,容器重建。

## 根因(两个 bug 叠加)

### Bug A — rclone_config_path 跟 mounted volume 错位(主因)

`src/config.py:39` `rclone_config_path: str = "./data/rclone.conf"`:
- 没有 `Field(alias="RCLONE_CONFIG_PATH")` env 别名 → Dockerfile 没法覆盖
- 容器 `WORKDIR /app` 下相对路径解析成 `/app/data/rclone.conf`
- 但 `/app/data` 是 `Dockerfile:76` `COPY --from=docs-index-fetcher` 的临时层,**不挂 volume**;持久化 volume 在 `/data`(`DATA_DIR=/data`)
- 容器一重建 → `/app/data/rclone.conf` 丢 → scheduled backup 找不到 conf → 失败

### Bug B — scheduled backup 不会自动重建 conf(兜底缺失)

`src/services/backup/runner.py::_run_with_remotes` 直接拿 `settings.rclone_config_path` 给 `RcloneRunner`,**不像** manual run-now 路径 `routers/admin_backup.py:507` 那样调 `RcloneConfigManager.rewrite_from_db()`。一旦 conf 文件丢了就再也不会被自动重建,直到用户在 web UI 上手动 edit 一次任意 remote。

## Fix

1. **`src/config.py`**:`rclone_config_path` 加 `Field(alias="RCLONE_CONFIG_PATH")`
2. **`Dockerfile`**:ENV 块加 `RCLONE_CONFIG_PATH=/data/rclone.conf`,跟 db/attachments/backups 一起持久化
3. **`src/services/backup/runner.py`**:`_run_with_remotes` 在 fan-out push 之前显式调 `RcloneConfigManager.rewrite_from_db(db, user_id)` 自愈

Fix 1+2 独立,任一项即解燃眉;两者一起做治本+兜底。

## Test plan

- [x] `pytest -k "backup or rclone"` 27 tests pass
- [x] `pytest` 全套 249 passed(1 pre-existing 无关 error)
- [x] env alias sanity:`RCLONE_CONFIG_PATH=/data/rclone.conf` env 能覆盖默认值
- [ ] Merge + 发版后:进容器 `ls -la /data/rclone.conf` 应能看到文件
- [ ] web UI 手动 run-now backup → succeeded
- [ ] `docker compose restart` 后不编辑 remote 再 run-now → 仍 succeeded(Fix 1 持久化生效)
- [ ] 容器内 `rm /data/rclone.conf` → run-now → 仍 succeeded(Fix 2 自愈生效)