### PR TITLE
fix: cascade tag rename for name-only transactions

### DIFF
--- a/src/projection.py
+++ b/src/projection.py
@@ -501,15 +501,35 @@ def rename_cascade_tag(
 
     if not old_name or not new_name or old_name == new_name:
         return
-    # tag_sync_ids_json 存的是 `["tag_a", "tag_b"]`,LIKE 匹配 "tag_a" 能框住
+    # 两条查询取并集:
+    #   1) tag_sync_ids_json 精确引用了该 tag sync_id (mobile/web 完整数据)
+    #   2) tags_csv 包含旧名称但没有 tag_sync_ids_json (legacy/不完整数据)
     like_pat = f'%"{tag_sync_id}"%'
-    rows = db.scalars(
+    rows_by_id = db.scalars(
         sql_select(ReadTxProjection).where(
             ReadTxProjection.user_id == user_id,
             ReadTxProjection.tag_sync_ids_json.like(like_pat),
         )
     ).all()
-    for row in rows:
+    # tags_csv 可能是 "旧标签" 或 "A,旧标签,B" 等逗号分隔形式;
+    # 用 LIKE 做粗筛,Python 侧按逗号拆分精确匹配防 substring 误伤。
+    like_name = f"%{old_name}%"
+    rows_by_name = db.scalars(
+        sql_select(ReadTxProjection).where(
+            ReadTxProjection.user_id == user_id,
+            ReadTxProjection.tags_csv.like(like_name),
+            ReadTxProjection.tag_sync_ids_json.is_(None),
+        )
+    ).all()
+    # 去重 (理论上不会重叠,但防御性合并)
+    seen: set[tuple[str, str]] = set()
+    all_rows = []
+    for row in (*rows_by_id, *rows_by_name):
+        key = (row.ledger_id, row.sync_id)
+        if key not in seen:
+            seen.add(key)
+            all_rows.append(row)
+    for row in all_rows:
         if not row.tags_csv:
             continue
         parts = [p.strip() for p in row.tags_csv.split(",") if p.strip()]

--- a/tests/test_projection_consistency.py
+++ b/tests/test_projection_consistency.py
@@ -250,6 +250,38 @@ def test_mobile_tag_rename_cascades_tx_projection():
         app.dependency_overrides.clear()
 
 
+def test_mobile_tag_rename_cascades_when_transaction_only_has_tag_name():
+    """Issue #5 regression: legacy/mobile tx may only carry tags_csv without tagIds.
+    Renaming the tag entity must still refresh existing transaction tag names.
+    """
+    client, engine, sf = _make_client()
+    try:
+        tok = _register_and_login(client, "m5-name-only@t.com", device_id="m1", client_type="app")
+        hdr = {"Authorization": f"Bearer {tok}"}
+        _push(client, hdr, "m1", "lg5_name_only", [
+            {"ledger_id": "lg5_name_only", "entity_type": "tag", "entity_sync_id": "g1",
+             "action": "upsert", "updated_at": _iso(),
+             "payload": {"syncId": "g1", "name": "旧标签"}},
+            {"ledger_id": "lg5_name_only", "entity_type": "transaction", "entity_sync_id": "t1",
+             "action": "upsert", "updated_at": _iso(),
+             "payload": {"syncId": "t1", "type": "expense", "amount": 5, "happenedAt": _iso(),
+                         "tags": "旧标签"}},
+        ])
+        later = datetime.now(timezone.utc) + timedelta(seconds=2)
+        _push(client, hdr, "m1", "lg5_name_only", [
+            {"ledger_id": "lg5_name_only", "entity_type": "tag", "entity_sync_id": "g1",
+             "action": "upsert", "updated_at": _iso(later),
+             "payload": {"syncId": "g1", "name": "新标签"}},
+        ])
+        lid = _get_ledger_internal_id(sf, "lg5_name_only")
+        with sf() as db:
+            tx = db.scalar(select(ReadTxProjection).where(
+                ReadTxProjection.ledger_id == lid, ReadTxProjection.sync_id == "t1"))
+            assert tx.tags_csv == "新标签", f"cascade failed, got {tx.tags_csv}"
+    finally:
+        app.dependency_overrides.clear()
+
+
 # --------------------------------------------------------------------------- #
 # web /write/* 驱动 projection 写入                                             #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- Fix tag rename cascade for transactions that only have tags_csv and no tagIds/tag_sync_ids_json
- Keep existing sync-id based cascade path for complete mobile/web data
- Add regression coverage for issue #5

## Root cause
rename_cascade_tag only selected transactions via tag_sync_ids_json. Legacy or incomplete transactions can store only the denormalized tag names in tags_csv, so they were skipped during tag rename.

## Test Plan
- [x] .venv/bin/python -m pytest tests/test_projection_consistency.py::test_mobile_tag_rename_cascades_when_transaction_only_has_tag_name -q
- [x] .venv/bin/python -m pytest tests/test_projection_consistency.py::test_mobile_tag_rename_cascades_tx_projection -q
- [x] .venv/bin/python -m pytest tests/test_projection_consistency.py -q

Closes #5