### PR TITLE
feat: add plugin runtime for mortgage auto accounting

### DIFF
--- a/docs/MORTGAGE_AUTO_ACCOUNTING.md
+++ b/docs/MORTGAGE_AUTO_ACCOUNTING.md
@@ -1,0 +1,66 @@
+# 插件机制与房贷自动记账
+
+BeeCount Cloud 通过通用插件运行时承载房贷等垂直记账能力，避免为每个业务场景在核心 write API 下新增专用 endpoint。
+
+## 插件接口
+
+```http
+GET /api/v1/plugins
+POST /api/v1/plugins/{plugin_id}/run
+```
+
+`GET /plugins` 返回插件清单和每个插件的 JSON Schema，Flutter / Web Console 可以据此动态渲染表单。
+
+`POST /plugins/{plugin_id}/run` 负责执行插件，并把插件生成的结果写成普通 BeeCount 交易。写入仍走现有 write/sync/projection 流程，支持 `Idempotency-Key`，并会广播同步变更给其他客户端。
+
+## 房贷插件
+
+内置 reference plugin:
+
+```text
+mortgage_auto_accounting
+```
+
+执行示例：
+
+```json
+{
+  "ledger_id": "ledger_xxx",
+  "base_change_id": 0,
+  "input": {
+    "loan_name": "家庭房贷",
+    "principal_amount": "1200000",
+    "annual_rate_percent": "3.6",
+    "term_months": 360,
+    "start_date": "2026-06-20",
+    "day_of_month": 20,
+    "repayment_method": "equal_principal_interest",
+    "account_name": "招商银行",
+    "principal_category_name": "房贷本金",
+    "interest_category_name": "房贷利息",
+    "prepayment_category_name": "提前还款",
+    "prepayments": [
+      {
+        "prepayment_date": "2027-01-10",
+        "amount": "50000",
+        "effect": "reduce_term"
+      }
+    ]
+  }
+}
+```
+
+## 还款方式
+
+- `equal_principal_interest`: 等额本息。
+- `equal_principal`: 等额本金。
+
+金额计算在服务端使用 `Decimal` 和整数分完成，最后写入 BeeCount 交易时才转换成两位小数金额。
+
+## 生成结果
+
+每期还款会生成普通支出交易：
+
+- 本金部分：默认分类 `房贷本金`。
+- 利息部分：默认分类 `房贷利息`。
+- 提前还款：默认分类 `提前还款`，并作为本金减少后续计划。

--- a/src/main.py
+++ b/src/main.py
@@ -22,7 +22,7 @@ from .logging_ring import install_ring_buffer
 from .metrics import metrics
 from .observability import configure_logging, install_request_middleware
 from .bootstrap_admin import ensure_admin
-from .routers import admin, attachments, auth, devices, pats, profile, read, sync, write, ws
+from .routers import admin, attachments, auth, devices, pats, plugins, profile, read, sync, write, ws
 from .routers import admin_backup, mcp_calls, two_factor
 from .routers import ai as ai_router
 from .routers import import_data as import_router
@@ -156,6 +156,7 @@ app.include_router(
 )
 app.include_router(read.router, prefix=f"{settings.api_prefix}/read", tags=["read"])
 app.include_router(write.router, prefix=f"{settings.api_prefix}/write", tags=["write"])
+app.include_router(plugins.router, prefix=settings.api_prefix, tags=["plugins"])
 app.include_router(attachments.router, prefix=f"{settings.api_prefix}/attachments", tags=["attachments"])
 app.include_router(profile.router, prefix=f"{settings.api_prefix}/profile", tags=["profile"])
 app.include_router(pats.router, prefix=f"{settings.api_prefix}/profile/pats", tags=["pats"])

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,0 +1,5 @@
+"""BeeCount Cloud built-in plugins."""
+
+from .registry import registry
+
+__all__ = ["registry"]

--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -1,0 +1,39 @@
+"""Minimal plugin runtime contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic import BaseModel
+
+
+@dataclass(frozen=True)
+class PluginRunResult:
+    transactions: list[dict[str, Any]] = field(default_factory=list)
+    summary: dict[str, Any] = field(default_factory=dict)
+
+
+PluginRunner = Callable[[BaseModel], PluginRunResult]
+
+
+@dataclass(frozen=True)
+class PluginDefinition:
+    plugin_id: str
+    name: str
+    description: str
+    input_model: type[BaseModel]
+    run: PluginRunner
+    name_i18n: dict[str, str] = field(default_factory=dict)
+    description_i18n: dict[str, str] = field(default_factory=dict)
+
+    def manifest(self) -> dict[str, Any]:
+        return {
+            "id": self.plugin_id,
+            "name": self.name,
+            "description": self.description,
+            "name_i18n": self.name_i18n,
+            "description_i18n": self.description_i18n,
+            "input_schema": self.input_model.model_json_schema(),
+        }

--- a/src/plugins/mortgage.py
+++ b/src/plugins/mortgage.py
@@ -1,0 +1,173 @@
+"""Mortgage auto-accounting reference plugin."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timezone
+from decimal import Decimal
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from ..services.mortgage import (
+    MortgagePrepayment,
+    build_mortgage_schedule,
+    cents_to_yuan,
+    yuan_to_cents,
+)
+from .base import PluginDefinition, PluginRunResult
+
+
+class MortgagePrepaymentInput(BaseModel):
+    prepayment_date: date
+    amount: Decimal = Field(gt=0)
+    effect: Literal["reduce_term", "reduce_payment"] = "reduce_term"
+
+
+class MortgagePluginInput(BaseModel):
+    loan_name: str = Field(default="房贷", min_length=1, max_length=80)
+    principal_amount: Decimal = Field(gt=0)
+    annual_rate_percent: Decimal = Field(ge=0)
+    term_months: int = Field(gt=0, le=600)
+    start_date: date
+    day_of_month: int = Field(ge=1, le=31)
+    repayment_method: Literal["equal_principal_interest", "equal_principal"]
+    account_name: str | None = None
+    account_id: str | None = None
+    principal_category_name: str = "房贷本金"
+    principal_category_id: str | None = None
+    interest_category_name: str = "房贷利息"
+    interest_category_id: str | None = None
+    prepayment_category_name: str = "提前还款"
+    prepayment_category_id: str | None = None
+    tag_names: list[str] = Field(default_factory=lambda: ["房贷"])
+    prepayments: list[MortgagePrepaymentInput] = Field(default_factory=list)
+
+
+def run_mortgage_plugin(input_model: BaseModel) -> PluginRunResult:
+    req = MortgagePluginInput.model_validate(input_model)
+    schedule = build_mortgage_schedule(
+        principal_cents=yuan_to_cents(req.principal_amount),
+        annual_rate_percent=req.annual_rate_percent,
+        term_months=req.term_months,
+        start_date=req.start_date,
+        day_of_month=req.day_of_month,
+        repayment_method=req.repayment_method,
+        prepayments=[
+            MortgagePrepayment(
+                prepayment_date=item.prepayment_date,
+                amount_cents=yuan_to_cents(item.amount),
+                effect=item.effect,
+            )
+            for item in req.prepayments
+        ],
+    )
+    transactions = _build_mortgage_tx_payloads(req, schedule)
+    return PluginRunResult(
+        transactions=transactions,
+        summary={
+            "schedule_entries": len(schedule),
+            "transaction_count": len(transactions),
+            "total_principal": cents_to_yuan(
+                sum(item.principal_cents + item.prepayment_cents for item in schedule)
+            ),
+            "total_interest": cents_to_yuan(sum(item.interest_cents for item in schedule)),
+            "total_prepayment": cents_to_yuan(sum(item.prepayment_cents for item in schedule)),
+        },
+    )
+
+
+def _build_mortgage_tx_payloads(
+    req: MortgagePluginInput,
+    schedule: list[Any],
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    tags = [tag.strip() for tag in req.tag_names if tag.strip()]
+    for entry in schedule:
+        if entry.prepayment_cents > 0:
+            out.append(
+                _tx_payload(
+                    amount=cents_to_yuan(entry.prepayment_cents),
+                    happened_at=_as_utc_datetime(entry.prepayment_date or entry.due_date),
+                    note=f"{req.loan_name} 提前还款",
+                    category_name=req.prepayment_category_name,
+                    category_id=req.prepayment_category_id,
+                    account_name=req.account_name,
+                    account_id=req.account_id,
+                    tags=tags,
+                )
+            )
+            continue
+        if entry.principal_cents > 0:
+            out.append(
+                _tx_payload(
+                    amount=cents_to_yuan(entry.principal_cents),
+                    happened_at=_as_utc_datetime(entry.due_date),
+                    note=f"{req.loan_name} 第{entry.period_index}期本金",
+                    category_name=req.principal_category_name,
+                    category_id=req.principal_category_id,
+                    account_name=req.account_name,
+                    account_id=req.account_id,
+                    tags=tags,
+                )
+            )
+        if entry.interest_cents > 0:
+            out.append(
+                _tx_payload(
+                    amount=cents_to_yuan(entry.interest_cents),
+                    happened_at=_as_utc_datetime(entry.due_date),
+                    note=f"{req.loan_name} 第{entry.period_index}期利息",
+                    category_name=req.interest_category_name,
+                    category_id=req.interest_category_id,
+                    account_name=req.account_name,
+                    account_id=req.account_id,
+                    tags=tags,
+                )
+            )
+    return out
+
+
+def _tx_payload(
+    *,
+    amount: float,
+    happened_at: datetime,
+    note: str,
+    category_name: str,
+    category_id: str | None,
+    account_name: str | None,
+    account_id: str | None,
+    tags: list[str],
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "tx_type": "expense",
+        "amount": amount,
+        "happened_at": happened_at.isoformat(),
+        "note": note,
+        "category_name": category_name,
+        "category_kind": "expense",
+    }
+    if category_id:
+        payload["category_id"] = category_id
+    if account_name:
+        payload["account_name"] = account_name
+    if account_id:
+        payload["account_id"] = account_id
+    if tags:
+        payload["tags"] = tags
+    return payload
+
+
+def _as_utc_datetime(value: date) -> datetime:
+    return datetime.combine(value, time(hour=12), tzinfo=timezone.utc)
+
+
+MORTGAGE_PLUGIN = PluginDefinition(
+    plugin_id="mortgage_auto_accounting",
+    name="Mortgage auto accounting",
+    description="Generate BeeCount transactions split into mortgage principal, interest, and prepayments.",
+    name_i18n={"zh-CN": "房贷自动记账"},
+    description_i18n={
+        "zh-CN": "根据利率、期限、还款方式和提前还款生成拆分本金/利息的 BeeCount 交易。"
+    },
+    input_model=MortgagePluginInput,
+    run=run_mortgage_plugin,
+)

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -1,0 +1,26 @@
+"""Built-in plugin registry."""
+
+from __future__ import annotations
+
+from .base import PluginDefinition
+from .mortgage import MORTGAGE_PLUGIN
+
+
+class PluginRegistry:
+    def __init__(self) -> None:
+        self._plugins: dict[str, PluginDefinition] = {}
+
+    def register(self, plugin: PluginDefinition) -> None:
+        if plugin.plugin_id in self._plugins:
+            raise ValueError(f"duplicated plugin id: {plugin.plugin_id}")
+        self._plugins[plugin.plugin_id] = plugin
+
+    def list(self) -> list[PluginDefinition]:
+        return list(self._plugins.values())
+
+    def get(self, plugin_id: str) -> PluginDefinition | None:
+        return self._plugins.get(plugin_id)
+
+
+registry = PluginRegistry()
+registry.register(MORTGAGE_PLUGIN)

--- a/src/routers/plugins.py
+++ b/src/routers/plugins.py
@@ -1,0 +1,261 @@
+"""Generic plugin discovery and execution endpoints."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from pydantic import BaseModel, Field, ValidationError
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from .. import snapshot_builder
+from ..concurrency import lock_ledger_for_materialize
+from ..config import get_settings
+from ..database import get_db
+from ..deps import get_current_user, require_any_scopes
+from ..models import AuditLog, SyncPushIdempotency, User
+from ..plugins import registry
+from ..security import SCOPE_APP_WRITE, SCOPE_WEB_READ, SCOPE_WEB_WRITE
+from ..snapshot_mutator import create_transaction
+from .write._shared import (
+    _TRANSACTION_WRITE_ROLES,
+    _emit_entity_diffs,
+    _hash_request,
+    _payload_with_actor,
+    _prepare_write,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+_LIST_SCOPE_DEP = require_any_scopes(SCOPE_APP_WRITE, SCOPE_WEB_READ, SCOPE_WEB_WRITE)
+_RUN_SCOPE_DEP = require_any_scopes(SCOPE_APP_WRITE, SCOPE_WEB_WRITE)
+
+
+class PluginRunRequest(BaseModel):
+    ledger_id: str = Field(min_length=1, max_length=128)
+    base_change_id: int = Field(default=0, ge=0)
+    input: dict[str, Any] = Field(default_factory=dict)
+
+
+class PluginRunResponse(BaseModel):
+    plugin_id: str
+    ledger_id: str
+    base_change_id: int
+    new_change_id: int
+    server_timestamp: datetime
+    created_sync_ids: list[str] = Field(default_factory=list)
+    summary: dict[str, Any] = Field(default_factory=dict)
+
+
+@router.get("/plugins")
+def list_plugins(
+    _scopes: set[str] = Depends(_LIST_SCOPE_DEP),
+    _current_user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    return {"plugins": [plugin.manifest() for plugin in registry.list()]}
+
+
+@router.post("/plugins/{plugin_id}/run", response_model=PluginRunResponse)
+async def run_plugin(
+    plugin_id: str,
+    req: PluginRunRequest,
+    request: Request,
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    device_id: str = Header(default="web-console", alias="X-Device-ID"),
+    _scopes: set[str] = Depends(_RUN_SCOPE_DEP),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> PluginRunResponse:
+    plugin = registry.get(plugin_id)
+    if plugin is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plugin not found")
+
+    payload_for_ide = req.model_dump(mode="json")
+    request_hash = _hash_request(request.method, request.url.path, payload_for_ide)
+    ledger, _ = _prepare_write(
+        db=db,
+        current_user=current_user,
+        ledger_external_id=req.ledger_id,
+        required_roles=_TRANSACTION_WRITE_ROLES,
+        idempotency_key=None,
+        device_id=device_id,
+        method=request.method,
+        path=request.url.path,
+        payload=payload_for_ide,
+    )
+    if idempotency_key:
+        replay = _load_plugin_idempotent_response(
+            db,
+            user_id=current_user.id,
+            device_id=device_id,
+            idempotency_key=idempotency_key,
+            request_hash=request_hash,
+        )
+        if replay is not None:
+            return replay
+
+    try:
+        plugin_input = plugin.input_model.model_validate(req.input)
+        result = plugin.run(plugin_input)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=exc.errors(include_context=False, include_url=False),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+
+    if not result.transactions:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Plugin produced no transactions",
+        )
+
+    lock_ledger_for_materialize(db, ledger.id)
+    if get_settings().strict_base_change_id:
+        latest_any_change_id = snapshot_builder.latest_change_id(db, ledger.id)
+        if req.base_change_id != latest_any_change_id:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={"message": "Write conflict", "latest_change_id": latest_any_change_id},
+            )
+
+    snapshot = snapshot_builder.build(db, ledger)
+    prev_snapshot = {**snapshot}
+    for key in ("items", "accounts", "categories", "tags", "budgets"):
+        arr = snapshot.get(key)
+        if isinstance(arr, list):
+            prev_snapshot[key] = [dict(e) if isinstance(e, dict) else e for e in arr]
+
+    created_sync_ids: list[str] = []
+    try:
+        for tx_payload in result.transactions:
+            snapshot, sync_id = create_transaction(
+                snapshot,
+                _payload_with_actor(tx_payload, current_user),
+            )
+            created_sync_ids.append(sync_id)
+    except (KeyError, ValueError, PermissionError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error_code": "PLUGIN_TX_INVALID", "message": str(exc)},
+        ) from exc
+
+    now = datetime.now(timezone.utc)
+    emitted_change_ids = _emit_entity_diffs(
+        db,
+        ledger=ledger,
+        current_user=current_user,
+        device_id=device_id,
+        prev=prev_snapshot,
+        next_snapshot=snapshot,
+        now=now,
+    )
+    new_change_id = max(emitted_change_ids) if emitted_change_ids else (
+        snapshot_builder.latest_change_id(db, ledger.id)
+    )
+    response = PluginRunResponse(
+        plugin_id=plugin.plugin_id,
+        ledger_id=ledger.external_id,
+        base_change_id=req.base_change_id,
+        new_change_id=new_change_id,
+        server_timestamp=now,
+        created_sync_ids=created_sync_ids,
+        summary=result.summary,
+    )
+
+    db.add(
+        AuditLog(
+            user_id=current_user.id,
+            ledger_id=ledger.id,
+            action="plugin_run",
+            metadata_json={
+                "pluginId": plugin.plugin_id,
+                "ledgerId": ledger.external_id,
+                "baseChangeId": req.base_change_id,
+                "newChangeId": new_change_id,
+                "createdCount": len(created_sync_ids),
+            },
+        )
+    )
+    if idempotency_key:
+        db.add(
+            SyncPushIdempotency(
+                user_id=current_user.id,
+                device_id=device_id,
+                idempotency_key=idempotency_key,
+                request_hash=request_hash,
+                response_json=response.model_dump(mode="json"),
+                created_at=now,
+                expires_at=now + timedelta(hours=24),
+            )
+        )
+
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        if idempotency_key:
+            replay = _load_plugin_idempotent_response(
+                db,
+                user_id=current_user.id,
+                device_id=device_id,
+                idempotency_key=idempotency_key,
+                request_hash=request_hash,
+            )
+            if replay is not None:
+                return replay
+        raise
+
+    logger.info(
+        "plugin.run plugin=%s ledger=%s tx_count=%d change_id=%d device=%s user=%s",
+        plugin.plugin_id,
+        ledger.external_id,
+        len(created_sync_ids),
+        new_change_id,
+        device_id,
+        current_user.id,
+    )
+    await request.app.state.ws_manager.broadcast_to_user(
+        ledger.user_id,
+        {
+            "type": "sync_change",
+            "ledgerId": ledger.external_id,
+            "serverCursor": new_change_id,
+            "serverTimestamp": now.isoformat(),
+        },
+    )
+    return response
+
+
+def _load_plugin_idempotent_response(
+    db: Session,
+    *,
+    user_id: str,
+    device_id: str,
+    idempotency_key: str,
+    request_hash: str,
+) -> PluginRunResponse | None:
+    row = db.scalar(
+        select(SyncPushIdempotency).where(
+            SyncPushIdempotency.user_id == user_id,
+            SyncPushIdempotency.device_id == device_id,
+            SyncPushIdempotency.idempotency_key == idempotency_key,
+        )
+    )
+    if row is None:
+        return None
+    if row.request_hash != request_hash:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Idempotency key reused with different payload",
+        )
+    return PluginRunResponse.model_validate(row.response_json)

--- a/src/services/mortgage.py
+++ b/src/services/mortgage.py
@@ -1,0 +1,183 @@
+"""Mortgage amortization helpers for generated bookkeeping entries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import ROUND_HALF_UP, Decimal
+
+CENT = Decimal("0.01")
+
+
+@dataclass(frozen=True)
+class MortgagePrepayment:
+    prepayment_date: date
+    amount_cents: int
+    effect: str = "reduce_term"
+
+
+@dataclass(frozen=True)
+class MortgageScheduleEntry:
+    period_index: int
+    due_date: date
+    principal_cents: int
+    interest_cents: int
+    remaining_principal_cents: int
+    prepayment_cents: int = 0
+    prepayment_date: date | None = None
+
+
+def yuan_to_cents(value: Decimal | float | int | str) -> int:
+    amount = Decimal(str(value)).quantize(CENT, rounding=ROUND_HALF_UP)
+    return int(amount * 100)
+
+
+def cents_to_yuan(cents: int) -> float:
+    return float((Decimal(cents) / Decimal(100)).quantize(CENT))
+
+
+def build_mortgage_schedule(
+    *,
+    principal_cents: int,
+    annual_rate_percent: Decimal,
+    term_months: int,
+    start_date: date,
+    day_of_month: int,
+    repayment_method: str,
+    prepayments: list[MortgagePrepayment] | None = None,
+) -> list[MortgageScheduleEntry]:
+    if principal_cents <= 0:
+        raise ValueError("principal must be positive")
+    if term_months <= 0:
+        raise ValueError("term_months must be positive")
+    if not 1 <= day_of_month <= 31:
+        raise ValueError("day_of_month must be between 1 and 31")
+    annual_rate_percent = Decimal(str(annual_rate_percent))
+    if annual_rate_percent < 0:
+        raise ValueError("annual_rate_percent must be non-negative")
+    if repayment_method not in {"equal_principal_interest", "equal_principal"}:
+        raise ValueError("unsupported repayment_method")
+
+    events = sorted(prepayments or [], key=lambda item: item.prepayment_date)
+    for event in events:
+        if event.amount_cents <= 0:
+            raise ValueError("prepayment amount must be positive")
+        if event.effect not in {"reduce_term", "reduce_payment"}:
+            raise ValueError("unsupported prepayment effect")
+
+    monthly_rate = annual_rate_percent / Decimal(100) / Decimal(12)
+    remaining = principal_cents
+    payment_cents = _equal_principal_interest_payment(
+        remaining,
+        monthly_rate,
+        term_months,
+    )
+    fixed_principal_cents = _round_cents(Decimal(principal_cents) / Decimal(term_months))
+    schedule: list[MortgageScheduleEntry] = []
+    event_index = 0
+
+    period = 1
+    while remaining > 0 and period <= term_months + len(events):
+        due_date = _add_months_with_day(start_date, period - 1, day_of_month)
+
+        while event_index < len(events) and events[event_index].prepayment_date <= due_date:
+            event = events[event_index]
+            paid = min(event.amount_cents, remaining)
+            remaining -= paid
+            schedule.append(
+                MortgageScheduleEntry(
+                    period_index=period,
+                    due_date=due_date,
+                    principal_cents=0,
+                    interest_cents=0,
+                    remaining_principal_cents=remaining,
+                    prepayment_cents=paid,
+                    prepayment_date=event.prepayment_date,
+                )
+            )
+            if event.effect == "reduce_payment":
+                remaining_months = max(term_months - period + 1, 1)
+                payment_cents = _equal_principal_interest_payment(
+                    remaining,
+                    monthly_rate,
+                    remaining_months,
+                )
+                fixed_principal_cents = _round_cents(
+                    Decimal(remaining) / Decimal(remaining_months)
+                )
+            event_index += 1
+            if remaining <= 0:
+                return schedule
+
+        interest_cents = _round_cents(Decimal(remaining) * monthly_rate)
+        if repayment_method == "equal_principal_interest":
+            principal_part = payment_cents - interest_cents
+            if principal_part <= 0:
+                principal_part = remaining
+        else:
+            principal_part = fixed_principal_cents
+
+        if period >= term_months:
+            principal_part = remaining
+        principal_part = min(principal_part, remaining)
+        remaining -= principal_part
+        schedule.append(
+            MortgageScheduleEntry(
+                period_index=period,
+                due_date=due_date,
+                principal_cents=principal_part,
+                interest_cents=max(interest_cents, 0),
+                remaining_principal_cents=remaining,
+            )
+        )
+        period += 1
+
+    while remaining > 0 and event_index < len(events):
+        event = events[event_index]
+        paid = min(event.amount_cents, remaining)
+        remaining -= paid
+        schedule.append(
+            MortgageScheduleEntry(
+                period_index=period,
+                due_date=event.prepayment_date,
+                principal_cents=0,
+                interest_cents=0,
+                remaining_principal_cents=remaining,
+                prepayment_cents=paid,
+                prepayment_date=event.prepayment_date,
+            )
+        )
+        event_index += 1
+    return schedule
+
+
+def _equal_principal_interest_payment(
+    principal_cents: int,
+    monthly_rate: Decimal,
+    months: int,
+) -> int:
+    if principal_cents <= 0:
+        return 0
+    if monthly_rate == 0:
+        return _round_cents(Decimal(principal_cents) / Decimal(months))
+    factor = (Decimal(1) + monthly_rate) ** months
+    payment = Decimal(principal_cents) * monthly_rate * factor / (factor - Decimal(1))
+    return _round_cents(payment)
+
+
+def _round_cents(value: Decimal) -> int:
+    return int(value.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+
+def _add_months_with_day(start: date, months: int, day_of_month: int) -> date:
+    month_index = start.month - 1 + months
+    year = start.year + month_index // 12
+    month = month_index % 12 + 1
+    return date(year, month, min(day_of_month, _days_in_month(year, month)))
+
+
+def _days_in_month(year: int, month: int) -> int:
+    if month == 12:
+        return 31
+    next_month = date(year, month + 1, 1)
+    return (next_month - date(year, month, 1)).days

--- a/tests/test_mortgage_generated_transactions.py
+++ b/tests/test_mortgage_generated_transactions.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import os
+from datetime import date
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.database import Base, get_db
+from src.main import app
+from src.models import ReadTxProjection
+from src.services.mortgage import build_mortgage_schedule, yuan_to_cents
+
+os.environ.setdefault("ALLOW_APP_RW_SCOPES", "false")
+os.environ.setdefault("REGISTRATION_ENABLED", "true")
+
+
+def _make_client() -> TestClient:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    def override_get_db():
+        db = Session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+def _register_and_login(client: TestClient, email: str) -> str:
+    client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "password": "Pa$$word1!",
+            "device_id": "d-web",
+            "client_type": "web",
+            "device_name": "pytest-web",
+            "platform": "test",
+        },
+    )
+    r = client.post(
+        "/api/v1/auth/login",
+        json={
+            "email": email,
+            "password": "Pa$$word1!",
+            "device_id": "d-web",
+            "client_type": "web",
+            "device_name": "pytest-web",
+            "platform": "test",
+        },
+    )
+    return r.json()["access_token"]
+
+
+def _create_ledger(client: TestClient, token: str) -> str:
+    r = client.post(
+        "/api/v1/write/ledgers",
+        json={"ledger_name": "home", "currency": "CNY"},
+        headers={"Authorization": f"Bearer {token}", "X-Device-ID": "d-web"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["entity_id"]
+
+
+def test_mortgage_schedule_splits_principal_and_interest():
+    schedule = build_mortgage_schedule(
+        principal_cents=yuan_to_cents("120000"),
+        annual_rate_percent="3.6",
+        term_months=12,
+        start_date=date(2026, 6, 20),
+        day_of_month=20,
+        repayment_method="equal_principal_interest",
+    )
+
+    assert len(schedule) == 12
+    assert sum(row.principal_cents for row in schedule) == 12_000_000
+    assert schedule[0].interest_cents == 36_000
+    assert schedule[0].principal_cents < schedule[-1].principal_cents
+
+
+def test_plugins_list_includes_mortgage_schema():
+    client = _make_client()
+    try:
+        token = _register_and_login(client, "plugins-list@test.com")
+        r = client.get(
+            "/api/v1/plugins",
+            headers={"Authorization": f"Bearer {token}", "X-Device-ID": "d-web"},
+        )
+
+        assert r.status_code == 200, r.text
+        plugins = r.json()["plugins"]
+        mortgage = next(
+            item for item in plugins if item["id"] == "mortgage_auto_accounting"
+        )
+        assert mortgage["name_i18n"]["zh-CN"] == "房贷自动记账"
+        assert "principal_amount" in mortgage["input_schema"]["properties"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_mortgage_plugin_creates_principal_interest_and_prepayment_transactions():
+    client = _make_client()
+    try:
+        token = _register_and_login(client, "mortgage1@test.com")
+        ledger_id = _create_ledger(client, token)
+        r = client.post(
+            "/api/v1/plugins/mortgage_auto_accounting/run",
+            json={
+                "ledger_id": ledger_id,
+                "base_change_id": 0,
+                "input": {
+                    "loan_name": "家庭房贷",
+                    "principal_amount": "120000",
+                    "annual_rate_percent": "3.6",
+                    "term_months": 12,
+                    "start_date": "2026-06-20",
+                    "day_of_month": 20,
+                    "repayment_method": "equal_principal_interest",
+                    "account_name": "招商银行",
+                    "prepayments": [
+                        {
+                            "prepayment_date": "2026-09-01",
+                            "amount": "10000",
+                            "effect": "reduce_payment",
+                        }
+                    ],
+                },
+            },
+            headers={"Authorization": f"Bearer {token}", "X-Device-ID": "d-web"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["plugin_id"] == "mortgage_auto_accounting"
+        assert body["summary"]["total_principal"] == 120000.0
+        assert body["summary"]["total_prepayment"] == 10000.0
+        assert body["summary"]["total_interest"] > 0
+        assert body["summary"]["transaction_count"] == len(body["created_sync_ids"])
+
+        db = next(app.dependency_overrides[get_db]())
+        try:
+            rows = db.scalars(
+                select(ReadTxProjection)
+                .where(ReadTxProjection.sync_id.in_(body["created_sync_ids"]))
+                .order_by(ReadTxProjection.happened_at, ReadTxProjection.note)
+            ).all()
+            assert len(rows) == body["summary"]["transaction_count"]
+            categories = {row.category_name for row in rows}
+            assert {"房贷本金", "房贷利息", "提前还款"} <= categories
+            assert {row.tx_type for row in rows} == {"expense"}
+            assert all((row.tags_csv or "") == "房贷" for row in rows)
+        finally:
+            db.close()
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_mortgage_plugin_idempotency_replays_created_ids():
+    client = _make_client()
+    try:
+        token = _register_and_login(client, "mortgage2@test.com")
+        ledger_id = _create_ledger(client, token)
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "X-Device-ID": "d-web",
+            "Idempotency-Key": "mortgage-same-request",
+        }
+        payload = {
+            "ledger_id": ledger_id,
+            "base_change_id": 0,
+            "input": {
+                "loan_name": "短贷",
+                "principal_amount": "30000",
+                "annual_rate_percent": "0",
+                "term_months": 3,
+                "start_date": "2026-06-20",
+                "day_of_month": 20,
+                "repayment_method": "equal_principal",
+            },
+        }
+        r1 = client.post(
+            "/api/v1/plugins/mortgage_auto_accounting/run",
+            json=payload,
+            headers=headers,
+        )
+        r2 = client.post(
+            "/api/v1/plugins/mortgage_auto_accounting/run",
+            json=payload,
+            headers=headers,
+        )
+
+        assert r1.status_code == 200, r1.text
+        assert r2.status_code == 200, r2.text
+        assert r2.json()["created_sync_ids"] == r1.json()["created_sync_ids"]
+        assert r2.json()["new_change_id"] == r1.json()["new_change_id"]
+
+        db = next(app.dependency_overrides[get_db]())
+        try:
+            count = len(db.scalars(select(ReadTxProjection)).all())
+            assert count == r1.json()["summary"]["transaction_count"]
+        finally:
+            db.close()
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- add a generic built-in plugin registry and authenticated `/plugins` discovery/run endpoints backed by JSON Schema manifests
- migrate mortgage auto accounting into a reference plugin instead of a dedicated `/write` business endpoint
- keep the Decimal/integer-cent amortization logic and generate normal BeeCount transactions through the existing write/sync/projection flow
- remove the README top-level feature claim until UI hosts can expose the plugin flow

## Validation
- `uv run --with-requirements requirements.txt python -m pytest tests/test_mortgage_generated_transactions.py -q`
- `uv run --with-requirements requirements.txt python -m pytest tests -q`
- `uv run --with-requirements requirements.txt ruff check src/plugins src/routers/plugins.py src/services/mortgage.py tests/test_mortgage_generated_transactions.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a plugin system enabling extensible functionality for specialized accounting tasks.
  * Added mortgage auto-accounting plugin that automatically generates loan payment transactions (principal, interest, and prepayment entries) with appropriate categorization.
  * Added REST API endpoints to discover available plugins and execute them with idempotency support via request headers.

* **Documentation**
  * Added comprehensive guide for mortgage auto-accounting capabilities and plugin system architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TNT-Likely/BeeCount-Cloud/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->