### PR TITLE
fix(并发): SQLite 启用 WAL + busy_timeout,修生产 'database is locked'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,6 @@ node_modules/
 *.log
 *.db
 *.db.bak*
+*.db-wal
+*.db-shm
 *.tsbuildinfo

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -26,7 +26,23 @@ SQLite:
 ./scripts/backup_sqlite.sh /data/beecount.db ./backups/sqlite
 ```
 
-Or simply snapshot the whole `beecount_data` volume — it contains DB, attachments, backups, avatars, and the JWT secret in one place.
+The script uses `sqlite3 .backup` (SQLite Online Backup API), which is **safe
+while the server is running** and works in any journal mode. Output is always
+a single clean db file — no `-wal` / `-shm` companions.
+
+> ⚠️ Don't `cp` the raw db file: the server runs in WAL mode, and a bare `cp`
+> will miss uncommitted writes still sitting in `beecount.db-wal`. Always use
+> the script (or `sqlite3 .backup` directly).
+
+For a full volume snapshot (DB + attachments + JWT secret + previous backups
+all together), simply tar the `beecount_data` volume after stopping the
+container, OR use `VACUUM INTO` via the in-app backup runner (admin UI →
+"Backup") which integrates with rclone.
+
+### Restore
+
+See [ROLLBACK_SOP.md](./ROLLBACK_SOP.md) — note the **delete `-wal` / `-shm`
+before overwriting** step required by WAL mode.
 
 ## 4) Security baseline
 

--- a/docs/ROLLBACK_SOP.md
+++ b/docs/ROLLBACK_SOP.md
@@ -3,12 +3,25 @@
 ## SQLite
 
 1. Stop app container.
-2. Restore db file:
-   - `cp backups/sqlite/beecount-<ts>.db /data/beecount.db`
-3. Start app container.
-4. Verify:
+2. **Remove old WAL helper files** (server runs in WAL mode — these belong to
+   the current db, not the backup):
+   ```bash
+   rm -f /data/beecount.db-wal /data/beecount.db-shm
+   ```
+3. Restore db file (backup is always a clean single file, no -wal / -shm):
+   ```bash
+   cp backups/sqlite/beecount-<ts>.db /data/beecount.db
+   ```
+4. Start app container. SQLite will auto-create new -wal / -shm on first
+   connection.
+5. Verify:
    - `GET /ready`
    - Web ledger list and one write smoke test.
+
+> Why step 2? In WAL mode `/data` contains `beecount.db` + `beecount.db-wal`
+> + `beecount.db-shm`. If you only overwrite `beecount.db` and leave the old
+> -wal around, SQLite will try to "recover" the old WAL log into the new
+> database and corrupt your restore. Always delete them first.
 
 ## PostgreSQL
 

--- a/scripts/backup_sqlite.sh
+++ b/scripts/backup_sqlite.sh
@@ -1,10 +1,33 @@
 #!/usr/bin/env bash
+# WAL-safe SQLite backup using SQLite Online Backup API (`sqlite3 .backup`).
+#
+# Why not `cp`?
+#   - WAL mode: `cp db.sqlite3` alone loses uncommitted writes still in -wal
+#   - DELETE mode: `cp` during active writes can produce a torn / corrupt file
+#
+# `sqlite3 .backup` works on a running database in any journal mode and
+# always produces a clean single-file snapshot (no -wal / -shm needed).
+#
+# Usage:
+#   ./backup_sqlite.sh [DB_PATH] [OUT_DIR]
+# Defaults:
+#   DB_PATH = /data/beecount.db
+#   OUT_DIR = ./backups/sqlite
 set -euo pipefail
 
 DB_PATH="${1:-/data/beecount.db}"
 OUT_DIR="${2:-./backups/sqlite}"
 TS="$(date +%Y%m%d-%H%M%S)"
+OUT_FILE="$OUT_DIR/beecount-${TS}.db"
 
 mkdir -p "$OUT_DIR"
-cp "$DB_PATH" "$OUT_DIR/beecount-${TS}.db"
-echo "backup created: $OUT_DIR/beecount-${TS}.db"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "ERROR: sqlite3 CLI not installed. apt: \`apt-get install sqlite3\`" >&2
+  exit 1
+fi
+
+# Online backup — server can keep writing during this. Output is always a
+# single, standalone, clean db file (no -wal / -shm), restorable everywhere.
+sqlite3 "$DB_PATH" ".backup '$OUT_FILE'"
+echo "backup created: $OUT_FILE"

--- a/src/database.py
+++ b/src/database.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
 from .config import get_settings
@@ -11,6 +11,35 @@ engine_kwargs: dict = {"pool_pre_ping": True}
 if settings.database_url.startswith("sqlite"):
     engine_kwargs["connect_args"] = {"check_same_thread": False}
 engine = create_engine(settings.database_url, **engine_kwargs)
+
+
+# 生产 SQLite 必配:WAL + busy_timeout。详见 .docs/sqlite-concurrency-fix.md
+#
+# 默认 journal_mode=DELETE + busy_timeout=0 在多 worker FastAPI 下会随机
+# 报 "database is locked" — 任何 writer 进入 PENDING 状态(等其它 reader
+# 退出),新 reader 都拿不到 SHARED 锁,立即报错。WAL 模式下 reader/writer
+# 走 MVCC 不互相阻塞。
+#
+# 这是生产部署基础设施配置,不是业务 bug。
+if settings.database_url.startswith("sqlite"):
+
+    @event.listens_for(engine, "connect")
+    def _sqlite_pragmas(dbapi_conn, _):
+        cur = dbapi_conn.cursor()
+        # WAL: reader 不阻塞 writer,writer 不阻塞 reader(MVCC)。
+        # 一次设置后持久化到 db 文件,后续 connection 自动是 WAL。
+        cur.execute("PRAGMA journal_mode=WAL")
+        # 写写互斥时等 5 秒再报错(默认 0 立即报)。
+        cur.execute("PRAGMA busy_timeout=5000")
+        # WAL 下推荐 NORMAL,数据不丢且写性能更好(DELETE 默认 FULL,fsync 太频繁)。
+        cur.execute("PRAGMA synchronous=NORMAL")
+        # SQLite 默认 FK 检查 OFF,显式开启让 ondelete=CASCADE 真生效。
+        cur.execute("PRAGMA foreign_keys=ON")
+        # 64MB page cache,大库读取性能大幅提升。
+        cur.execute("PRAGMA cache_size=-64000")
+        cur.close()
+
+
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 
 

--- a/tests/test_sqlite_wal.py
+++ b/tests/test_sqlite_wal.py
@@ -1,0 +1,81 @@
+"""SQLite WAL + busy_timeout 生产配置回归测试。
+
+锁定 src/database.py 里的 PRAGMA listener 不被无意改回。改坏会导致生产
+高并发下 "database is locked" 大面积爆。详见 .docs/sqlite-concurrency-fix.md。
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from src.database import SessionLocal, engine
+
+
+def test_engine_uses_wal_mode():
+    """每个新 connection 必须自动配 WAL + busy_timeout=5000。"""
+    if not str(engine.url).startswith("sqlite"):
+        pytest.skip("only sqlite backend needs WAL")
+    with engine.connect() as conn:
+        assert conn.exec_driver_sql("PRAGMA journal_mode").scalar() == "wal"
+        assert conn.exec_driver_sql("PRAGMA busy_timeout").scalar() == 5000
+        # synchronous=NORMAL = 1 (FULL=2, OFF=0)
+        assert conn.exec_driver_sql("PRAGMA synchronous").scalar() == 1
+        # foreign_keys=ON 让 ondelete=CASCADE 真生效
+        assert conn.exec_driver_sql("PRAGMA foreign_keys").scalar() == 1
+
+
+def test_concurrent_reader_writer_no_lock():
+    """WAL 模式下,长 reader 不应阻塞另一线程的 writer。
+
+    模拟数据清理 scan(长 SELECT)期间,普通 sync/pull(commit)能正常完成。
+    DELETE 模式下这种场景必然会有一方报 locked,WAL 模式下双方都成功。
+    """
+    if not str(engine.url).startswith("sqlite"):
+        pytest.skip("only sqlite backend has this lock semantic")
+
+    errors: list[Exception] = []
+    writer_ok = threading.Event()
+
+    def long_reader():
+        try:
+            with SessionLocal() as s:
+                # 模拟 scanner 的长 SELECT —— 拿 sqlite_master 一定有结果,不依赖业务表
+                s.execute(_text("SELECT name FROM sqlite_master"))
+                time.sleep(1.0)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    def writer():
+        try:
+            # 等 reader 先起来
+            time.sleep(0.2)
+            with SessionLocal() as s:
+                s.execute(_text("CREATE TABLE IF NOT EXISTS _wal_test (id INTEGER PRIMARY KEY)"))
+                s.execute(_text("INSERT INTO _wal_test DEFAULT VALUES"))
+                s.commit()
+                writer_ok.set()
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    t1 = threading.Thread(target=long_reader)
+    t2 = threading.Thread(target=writer)
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+    assert not errors, f"WAL 模式下读写不应互相阻塞: {errors}"
+    assert writer_ok.is_set(), "writer 应在 reader 还在跑时就完成"
+
+    # 清理
+    with SessionLocal() as s:
+        s.execute(_text("DROP TABLE IF EXISTS _wal_test"))
+        s.commit()
+
+
+def _text(sql: str):
+    """局部 helper,避免 import sqlalchemy 顶层。"""
+    from sqlalchemy import text as _t
+
+    return _t(sql)


### PR DESCRIPTION
## Summary

修生产暴露的 \`sqlite3.OperationalError: database is locked\`,涉及数据清理 scan、多设备并发 sync、login / get_current_user 等所有读写路径。

## 根因

SQLite 默认 \`journal_mode=DELETE\` + \`busy_timeout=0\` 在多 worker FastAPI 下:
- writer 进入 PENDING(等其它 reader 退出)时,**SQLite 拒绝新 reader 拿 SHARED 锁**(让位机制)
- 加上 \`busy_timeout=0\`,拿不到锁立即报错而非等待
- 任何两个并发的写(_bump_device_last_seen / sync_cursor commit / push 写 sync_changes)都可能撞
- scan 长 SELECT 把这个现象放大成持续报错

详细分析见 [.docs/sqlite-concurrency-fix.md](.docs/sqlite-concurrency-fix.md)(完整事故链 ABC + WAL 工作原理 + 行业实践对照)。

## 修复

| 文件 | 改动 |
|---|---|
| \`src/database.py\` | \`@event.listens_for('connect')\` 配 PRAGMA: \`journal_mode=WAL\` + \`busy_timeout=5000\` + \`synchronous=NORMAL\` + \`foreign_keys=ON\` + \`cache_size=-64000\` |
| \`scripts/backup_sqlite.sh\` | \`cp\` → \`sqlite3 .backup\`(SQLite Online Backup,WAL-safe,运行时可备) |
| \`docs/ROLLBACK_SOP.md\` | 恢复加 \`rm -f db-wal db-shm\` 步骤 — 否则 SQLite 会把旧 wal 合并进新 db 导致数据损坏 |
| \`docs/DEPLOYMENT.md\` | 备份 / 恢复说明同步 |
| \`.gitignore\` | 加 \`*.db-wal\` \`*.db-shm\` |
| \`tests/test_sqlite_wal.py\` | 新增 2 case 锁定配置 + 并发读写不阻塞 |

## 测试

- \`pytest tests/test_sqlite_wal.py\` 全过(PRAGMA 配置 + 并发 reader/writer)
- \`pytest tests/test_data_cleanup.py tests/test_attachment_gc.py\` 全过,无回归

## 部署影响

- **服务**:重启一次即可生效(PRAGMA 在 db 文件级持久化)
- **备份**:已自动 WAL-safe,无需改动 cron / rclone 任务
- **恢复**:从备份还原时按 ROLLBACK_SOP.md 走 — 先 \`rm -f /data/beecount.db-wal /data/beecount.db-shm\` 再 cp 新 db,启服务后 SQLite 自动重建辅助文件

## 行业实践

WAL 是 SQLite + 多 worker web 服务的事实标配,同类 self-host 项目(Plausible / Umami / Memos / Linkwarden / Bookstack 等)全部默认启用。不开 WAL 是历史遗留配置,生产部署必修。