### PR TITLE
fix: batch create 反查 tag sync_id,根治 name-only projection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,7 @@ migrate:
 	. .venv/bin/activate && alembic upgrade head
 
 
-#   env -u SSL_CERT_FILE -u REQUESTS_CA_BUNDLE -u NODE_EXTRA_CA_CERTS \
-#       -u AWS_CA_BUNDLE \
-#       HTTPS_PROXY=http://192.168.3.202:7890 \
-#       HTTP_PROXY=http://192.168.3.202:7890 \
-#       ALL_PROXY=http://192.168.3.202:7890 \
-#       make dev-api
+#   env -u SSL_CERT_FILE -u REQUESTS_CA_BUNDLE -u NODE_EXTRA_CA_CERTS -u AWS_CA_BUNDLE HTTPS_PROXY=http://192.168.3.202:7890 HTTP_PROXY=http://192.168.3.202:7890 ALL_PROXY=http://192.168.3.202:7890 make dev-api
 #
 dev-api: setup-backend migrate
 	# --host 0.0.0.0 必要：模拟器/手机经 WiFi 用 IP 访问时才能连进来。

--- a/src/routers/write/transactions_batch.py
+++ b/src/routers/write/transactions_batch.py
@@ -40,7 +40,7 @@ from ...models import (
 )
 from ...security import SCOPE_APP_WRITE, SCOPE_WEB_WRITE
 from ...services.ai.image_cache import consume_image
-from ...snapshot_mutator import create_transaction
+from ...snapshot_mutator import create_tag, create_transaction
 from ._shared import (
     _TRANSACTION_WRITE_ROLES,
     _WRITE_RESPONSES,
@@ -194,15 +194,43 @@ async def create_tx_batch(
         if isinstance(arr, list):
             prev_snapshot[_k] = [dict(e) if isinstance(e, dict) else e for e in arr]
 
-    # 4. 预查所有标签名 → sync_id,避免每笔 tx 触发 N 次 lookup,顺便修
-    # issue #5 根因(batch 路径之前不反查导致 tag_sync_ids_json 为 NULL)。
-    all_tag_names: set[str] = set(auto_tag_names)
+    # 4. Ensure 所有用到的 tag 名字都在 snapshot.tags 里有实体,得到 name→sync_id map。
+    #
+    # 历史问题:_resolve_or_make_ai_tag_name 名字误导 — 它只 "resolve or pick a
+    # default *name*",**不创建实体**。extra_tag_name(图片/文字记账)更直接,
+    # 字符串 append 完就完事。导致 batch 创建的 tx 上看得到 chip,但 Tags 管理
+    # 页里这俩 tag 不存在 → tag_sync_ids_json 也填不上,Tags 详情查不到关联 tx。
+    #
+    # 这里改成跟 mobile 行为对齐:发现 snapshot.tags 里没这个名字 → 用
+    # snapshot_mutator.create_tag 实际建实体,后续 _emit_entity_diffs 会把它
+    # emit 成 SyncChange + 写 UserTagProjection。tx payload 直接引用 sync_id。
+    tag_name_to_sync_id: dict[str, str] = {}
+    existing_tags = snapshot.get("tags") or []
+    for t in existing_tags:
+        n = (t.get("name") or "").strip()
+        if n:
+            tag_name_to_sync_id.setdefault(n, str(t.get("syncId") or ""))
+
+    needed_names: set[str] = {n for n in auto_tag_names if n}
     for _item in req.transactions:
         if _item.tags:
-            all_tag_names.update(t for t in _item.tags if t)
-    tag_name_to_sync_id = _lookup_tag_sync_ids_map(
-        db, user_id=current_user.id, names=list(all_tag_names),
-    )
+            needed_names.update(t for t in _item.tags if t)
+
+    for name in needed_names:
+        if name in tag_name_to_sync_id and tag_name_to_sync_id[name]:
+            continue
+        tag_payload = _payload_with_actor({"name": name}, current_user)
+        try:
+            snapshot, new_sync_id = create_tag(snapshot, tag_payload)
+            tag_name_to_sync_id[name] = new_sync_id
+        except ValueError:
+            # create_tag 内部 dup name 会 raise,理论上前面已 dedup 不会到这。
+            # 防御性重扫 snapshot 找同名 sync_id,实在没有就放弃(让 tx 带
+            # name-only 落库,跟历史行为兼容)。
+            for t in snapshot.get("tags") or []:
+                if (t.get("name") or "").strip() == name:
+                    tag_name_to_sync_id[name] = str(t.get("syncId") or "")
+                    break
 
     # 5. 循环 mutate snapshot,创建 N 笔
     created_sync_ids: list[str] = []
@@ -319,35 +347,6 @@ async def create_tx_batch(
 
 
 # ──────────────────────────────────────────────────────────────────────
-
-
-def _lookup_tag_sync_ids_map(
-    db: Session, *, user_id: str, names: list[str]
-) -> dict[str, str]:
-    """批量把 tag 名字解析成 sync_id(user-global),返回 name → sync_id map。
-
-    跟 src/mcp/tools/write_tools.py::_lookup_tag_sync_ids 同语义,只是这里
-    返回 dict 方便 batch 路径多次反查不重复打表 + 避免 N+1。没找到的 name
-    不出现在 dict 里。
-
-    存在的意义:batch API 历史上 schema 没 tag_ids 字段,所有 LLM 记账走
-    batch 都只有 tags 名字,导致 ReadTxProjection.tag_sync_ids_json 为
-    NULL,后续 tag rename 走 sync_id 路径会漏掉这些行。这里 server 主动
-    反查,把 sync_id 一起塞进 payload,根治 issue #5 的 name-only 数据
-    源头(PR #9 是 rename cascade 端的补救,这里是源头治理)。
-    """
-    if not names:
-        return {}
-    rows = db.execute(
-        select(UserTagProjection.name, UserTagProjection.sync_id).where(
-            UserTagProjection.user_id == user_id,
-            UserTagProjection.name.in_(names),
-        )
-    ).all()
-    out: dict[str, str] = {}
-    for n, sid in rows:
-        out.setdefault(n, sid)
-    return out
 
 
 def _build_tx_payload(

--- a/src/routers/write/transactions_batch.py
+++ b/src/routers/write/transactions_batch.py
@@ -194,7 +194,17 @@ async def create_tx_batch(
         if isinstance(arr, list):
             prev_snapshot[_k] = [dict(e) if isinstance(e, dict) else e for e in arr]
 
-    # 4. 循环 mutate snapshot,创建 N 笔
+    # 4. 预查所有标签名 → sync_id,避免每笔 tx 触发 N 次 lookup,顺便修
+    # issue #5 根因(batch 路径之前不反查导致 tag_sync_ids_json 为 NULL)。
+    all_tag_names: set[str] = set(auto_tag_names)
+    for _item in req.transactions:
+        if _item.tags:
+            all_tag_names.update(t for t in _item.tags if t)
+    tag_name_to_sync_id = _lookup_tag_sync_ids_map(
+        db, user_id=current_user.id, names=list(all_tag_names),
+    )
+
+    # 5. 循环 mutate snapshot,创建 N 笔
     created_sync_ids: list[str] = []
     try:
         for i, item in enumerate(req.transactions):
@@ -203,6 +213,7 @@ async def create_tx_batch(
                 auto_tag_names=auto_tag_names,
                 attachment_dict=attachment_dict,
                 actor_user=current_user,
+                tag_name_to_sync_id=tag_name_to_sync_id,
             )
             snapshot, sync_id = create_transaction(snapshot, tx_payload)
             if sync_id:
@@ -310,15 +321,50 @@ async def create_tx_batch(
 # ──────────────────────────────────────────────────────────────────────
 
 
+def _lookup_tag_sync_ids_map(
+    db: Session, *, user_id: str, names: list[str]
+) -> dict[str, str]:
+    """批量把 tag 名字解析成 sync_id(user-global),返回 name → sync_id map。
+
+    跟 src/mcp/tools/write_tools.py::_lookup_tag_sync_ids 同语义,只是这里
+    返回 dict 方便 batch 路径多次反查不重复打表 + 避免 N+1。没找到的 name
+    不出现在 dict 里。
+
+    存在的意义:batch API 历史上 schema 没 tag_ids 字段,所有 LLM 记账走
+    batch 都只有 tags 名字,导致 ReadTxProjection.tag_sync_ids_json 为
+    NULL,后续 tag rename 走 sync_id 路径会漏掉这些行。这里 server 主动
+    反查,把 sync_id 一起塞进 payload,根治 issue #5 的 name-only 数据
+    源头(PR #9 是 rename cascade 端的补救,这里是源头治理)。
+    """
+    if not names:
+        return {}
+    rows = db.execute(
+        select(UserTagProjection.name, UserTagProjection.sync_id).where(
+            UserTagProjection.user_id == user_id,
+            UserTagProjection.name.in_(names),
+        )
+    ).all()
+    out: dict[str, str] = {}
+    for n, sid in rows:
+        out.setdefault(n, sid)
+    return out
+
+
 def _build_tx_payload(
     *,
     item: BatchTransactionItem,
     auto_tag_names: list[str],
     attachment_dict: dict | None,
     actor_user: User,
+    tag_name_to_sync_id: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """把 BatchTransactionItem + 自动 tag + 共享 attachment 拼成 single create
-    所需的 payload(对应 WriteTransactionCreateRequest schema)。"""
+    所需的 payload(对应 WriteTransactionCreateRequest schema)。
+
+    `tag_name_to_sync_id`(可选):name → sync_id map,batch 路径预先 lookup
+    传进来,让 payload 同时带 tags(名字)+ tag_ids(sync_id),projection 写入
+    时 tag_sync_ids_json 才完整。
+    """
     payload: dict[str, Any] = {
         "tx_type": item.tx_type,
         "amount": item.amount,
@@ -339,6 +385,16 @@ def _build_tx_payload(
     merged_tags = user_tags + [t for t in auto_tag_names if t and t not in user_tags]
     if merged_tags:
         payload["tags"] = merged_tags
+        # 反查 sync_id 一起传 — 让 projection.tag_sync_ids_json 完整填充。
+        # 否则 tag rename 走 sync_id 路径会漏掉这笔 tx(issue #5 根因)。
+        # 找不到 sync_id 的 name 静默丢弃,不阻塞 tx 创建(可能是 LLM 抽出的
+        # 全新 tag 名字,稍后 snapshot 同步 emit 时会创建 tag 实体)。
+        if tag_name_to_sync_id:
+            tag_ids = [
+                tag_name_to_sync_id[n] for n in merged_tags if n in tag_name_to_sync_id
+            ]
+            if tag_ids:
+                payload["tag_ids"] = tag_ids
 
     if attachment_dict is not None:
         payload["attachments"] = [attachment_dict]

--- a/tests/test_ai_parse_tx.py
+++ b/tests/test_ai_parse_tx.py
@@ -395,3 +395,80 @@ def test_batch_create_with_image_attachment(monkeypatch):
         assert len(body["created_sync_ids"]) == 1
     finally:
         app.dependency_overrides.clear()
+
+
+def test_batch_create_fills_tag_sync_ids_for_existing_tags():
+    """Issue #5 根因修复:batch create 路径(B2/B3 LLM 记账)只接受 tags 名字,
+    之前不反查 sync_id,导致 ReadTxProjection.tag_sync_ids_json 永远 NULL。
+
+    现在 server 主动 lookup 已有 tag 的 sync_id,把它和名字一起写入 projection,
+    后续 tag rename 走 sync_id 路径不再漏掉这笔 tx。
+    """
+    from sqlalchemy import select
+    from src.models import ReadTxProjection
+
+    client = _make_client()
+    try:
+        token, _uid = _register_and_login(client, "bat-tag-id@test.com", client_type="web")
+        hdr = {"Authorization": f"Bearer {token}", "X-Device-ID": "d-web"}
+
+        # 1. 创建 ledger
+        r = client.post(
+            "/api/v1/write/ledgers",
+            json={"ledger_name": "default", "currency": "CNY"},
+            headers=hdr,
+        )
+        assert r.status_code == 200, r.text
+        ledger_id = r.json()["entity_id"]
+        change_id = r.json()["new_change_id"]
+
+        # 2. 先创建一个已存在的 tag「旅行」,记下 sync_id
+        r = client.post(
+            f"/api/v1/write/ledgers/{ledger_id}/tags",
+            json={"base_change_id": change_id, "name": "旅行"},
+            headers=hdr,
+        )
+        assert r.status_code == 200, r.text
+        travel_tag_sync_id = r.json()["entity_id"]
+        change_id = r.json()["new_change_id"]
+
+        # 3. 走 batch 路径创建 tx,只传 tags 名字(模拟 B2/B3 LLM 记账场景)
+        r = client.post(
+            f"/api/v1/write/ledgers/{ledger_id}/transactions/batch",
+            json={
+                "base_change_id": change_id,
+                "transactions": [{
+                    "tx_type": "expense",
+                    "amount": 1280.0,
+                    "happened_at": "2026-05-21T12:00:00Z",
+                    "note": "酒店",
+                    "tags": ["旅行"],
+                }],
+                "auto_ai_tag": False,
+                "locale": "zh",
+            },
+            headers=hdr,
+        )
+        assert r.status_code == 200, r.text
+        tx_sync_id = r.json()["created_sync_ids"][0]
+
+        # 4. 验证 projection 的 tag_sync_ids_json 已被填充(修复目标)
+        db = next(app.dependency_overrides[get_db]())
+        try:
+            tx = db.scalar(
+                select(ReadTxProjection).where(ReadTxProjection.sync_id == tx_sync_id)
+            )
+            assert tx is not None, "projection row missing"
+            assert tx.tags_csv == "旅行", f"tags_csv 应保留名字, 实际={tx.tags_csv}"
+            assert tx.tag_sync_ids_json is not None, (
+                "tag_sync_ids_json 应被 batch 路径 lookup 填充, 当前 NULL "
+                "= issue #5 根因未修"
+            )
+            sync_ids = json.loads(tx.tag_sync_ids_json)
+            assert travel_tag_sync_id in sync_ids, (
+                f"期望 {travel_tag_sync_id} ∈ {sync_ids}"
+            )
+        finally:
+            db.close()
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_ai_parse_tx.py
+++ b/tests/test_ai_parse_tx.py
@@ -397,6 +397,83 @@ def test_batch_create_with_image_attachment(monkeypatch):
         app.dependency_overrides.clear()
 
 
+def test_batch_create_materializes_auto_tag_entities():
+    """B2/B3 LLM 记账场景:auto_ai_tag + extra_tag_name 之前只是字符串塞 tags_csv,
+    UserTagProjection 没行,Tags 详情页查不到关联 tx。
+
+    现在 batch 路径会:
+    1. 在 snapshot 里实际 create_tag 实体(走 snapshot_mutator + diff emit)
+    2. tx payload 引用其 sync_id
+    3. UserTagProjection 写入 + ReadTxProjection.tag_sync_ids_json 完整填充
+    """
+    from sqlalchemy import select
+    from src.models import ReadTxProjection, UserTagProjection
+
+    client = _make_client()
+    try:
+        token, uid = _register_and_login(client, "bat-auto-tag@test.com", client_type="web")
+        hdr = {"Authorization": f"Bearer {token}", "X-Device-ID": "d-web"}
+
+        r = client.post(
+            "/api/v1/write/ledgers",
+            json={"ledger_name": "default", "currency": "CNY"},
+            headers=hdr,
+        )
+        assert r.status_code == 200, r.text
+        ledger_id = r.json()["entity_id"]
+        change_id = r.json()["new_change_id"]
+
+        # batch 创建,auto_ai_tag=True + extra_tag_name="文字记账"
+        # 完全没预先创建任何 tag,期望 server 自动建实体
+        r = client.post(
+            f"/api/v1/write/ledgers/{ledger_id}/transactions/batch",
+            json={
+                "base_change_id": change_id,
+                "transactions": [{
+                    "tx_type": "expense",
+                    "amount": 20.0,
+                    "happened_at": "2026-05-21T09:47:00Z",
+                    "note": "买菜",
+                    "tags": [],
+                }],
+                "auto_ai_tag": True,
+                "extra_tag_name": "文字记账",
+                "locale": "zh",
+            },
+            headers=hdr,
+        )
+        assert r.status_code == 200, r.text
+        tx_sync_id = r.json()["created_sync_ids"][0]
+
+        # 验证 1:UserTagProjection 里有「AI记账」+「文字记账」两个 tag 实体
+        db = next(app.dependency_overrides[get_db]())
+        try:
+            tag_rows = db.scalars(
+                select(UserTagProjection).where(UserTagProjection.user_id == uid)
+            ).all()
+            tag_names = {t.name for t in tag_rows}
+            assert "AI记账" in tag_names, f"AI记账 tag 实体未创建, 现有={tag_names}"
+            assert "文字记账" in tag_names, f"文字记账 tag 实体未创建, 现有={tag_names}"
+            name_to_sync_id = {t.name: t.sync_id for t in tag_rows}
+
+            # 验证 2:这笔 tx 的 projection tag_sync_ids_json 包含两个 sync_id
+            tx = db.scalar(
+                select(ReadTxProjection).where(ReadTxProjection.sync_id == tx_sync_id)
+            )
+            assert tx is not None
+            assert tx.tags_csv and "AI记账" in tx.tags_csv and "文字记账" in tx.tags_csv
+            assert tx.tag_sync_ids_json is not None, (
+                "tag_sync_ids_json 应被填充,实际 NULL = 修复未生效"
+            )
+            sync_ids = json.loads(tx.tag_sync_ids_json)
+            assert name_to_sync_id["AI记账"] in sync_ids
+            assert name_to_sync_id["文字记账"] in sync_ids
+        finally:
+            db.close()
+    finally:
+        app.dependency_overrides.clear()
+
+
 def test_batch_create_fills_tag_sync_ids_for_existing_tags():
     """Issue #5 根因修复:batch create 路径(B2/B3 LLM 记账)只接受 tags 名字,
     之前不反查 sync_id,导致 ReadTxProjection.tag_sync_ids_json 永远 NULL。


### PR DESCRIPTION
## Summary

延续 #9 的修复,但治在源头:让 batch create 路径(B2 图片记账 / B3 文字记账 / Web 端批量录入)写入交易时,既反查/创建 tag 实体,又把 sync_id 写进 ReadTxProjection,避免再产生 name-only 数据。

## Root cause(两层)

**第 1 层**:\`BatchTransactionItem\` schema 没有 \`tag_ids\` 字段,\`_build_tx_payload\` 拼 payload 时也不反查 sync_id,导致 \`ReadTxProjection.tag_sync_ids_json\` 写入 NULL。tag rename 走 sync_id 路径(\`rename_cascade_tag\`)漏数据 = issue #5 根因。

**第 2 层(验收发现)**:\`_resolve_or_make_ai_tag_name\` 函数名误导,它只 "resolve or pick a default *name*",**不创建 UserTagProjection 实体**。\`extra_tag_name\`(图片记账/文字记账)更直接,字符串 append 完就完事。导致 batch 创建的 tx chip 显示「AI 记账」「文字记账」但 Tags 管理页里这两个 tag 不存在,Tags 详情页也查不到关联 tx。

## Fix

在 \`create_batch\` 主循环之前:

1. 扫 \`snapshot.tags\` 得到已有 name → sync_id map
2. union 所有 auto_tag_names + item.tags,对缺失的 name 用 \`snapshot_mutator.create_tag\` 实际创建实体(行为跟 mobile 创建 tag 完全一致,走 \`_emit_entity_diffs\` emit SyncChange)
3. \`_build_tx_payload\` 拿这个 map,把 sync_id 写进 \`payload["tag_ids"]\`,\`snapshot_mutator.create_transaction\` 已经会读这个字段填 \`item["tagIds"]\`

**不改 API schema、不动前端、不破坏既有契约** — 纯 server 端 + 同事务内处理。

## 受影响场景

唯一调用方:\`POST /api/v1/write/ledgers/{ledger_id}/transactions/batch\`,即 ⌘K AI 记账确认页(\`frontend/.../cmdk-ai/TxDraftList.tsx\`)的 B2 截图记账 / B3 文字记账。

| 标签来源 | 修复前 | 修复后 |
|---|---|---|
| \`auto_ai_tag=true\` → 「AI 记账」 | tags_csv 有名字,UserTagProjection 没行,tag_sync_ids_json NULL | UserTagProjection 实际有「AI 记账」行 + tx tag_sync_ids_json 包含其 sync_id |
| \`extra_tag_name\` → 「图片记账」/「文字记账」 | 同上 | 同上 |
| LLM 抽出已有标签名 | sync_id 漏(本 PR 之前修一半) | 反查到 sync_id 写入 |
| LLM 抽出全新标签名 | 仅 tags_csv | 自动建实体 + sync_id 完整 |

不影响:mobile sync push / 单笔 write / MCP create_transaction / batch delete / Tags rename cascade(由 #9 兜底)。

## Test Plan

- [x] 新增 \`test_batch_create_materializes_auto_tag_entities\`:不预创建任何 tag → batch + auto_ai_tag + extra_tag_name → 验证 UserTagProjection 实际有「AI 记账」「文字记账」两行 + tx projection 引用正确 sync_id
- [x] 新增 \`test_batch_create_fills_tag_sync_ids_for_existing_tags\`:复用已有 tag 场景
- [x] \`.venv/bin/python -m pytest tests/test_ai_parse_tx.py tests/test_projection_consistency.py -q\` → 23/23

## 验收 checkpoint

1. ⌘K 文字记账,内容随便,**勾着「自动加 AI 记账标签」**,保存
2. 去 Tags 管理页 → 应该能看到「AI 记账」+「文字记账」两个 tag(以前完全没有)
3. 点「AI 记账」→ 详情页应列出刚才那笔(以前列表为空)
4. 把「AI 记账」改名为「AI 智能记账」→ 那笔 tx 标签同步更新(PR #9 兜底)