### PR TITLE
fix: 分类预算聚合子分类支出（Issue #15）

### DIFF
--- a/frontend/apps/web/src/pages/sections/OverviewPage.tsx
+++ b/frontend/apps/web/src/pages/sections/OverviewPage.tsx
@@ -134,6 +134,7 @@ export function OverviewPage() {
       const { budgets: b, usageById } = await fetchBudgetsWithUsage(
         token,
         activeLedgerId,
+        categories,
       )
       setBudgets(b)
       setBudgetUsageById(usageById)
@@ -144,7 +145,7 @@ export function OverviewPage() {
     }
     // setBudgets / setBudgetUsageById 是 usePageCache 返回的稳定 setter
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token, activeLedgerId])
+  }, [token, activeLedgerId, categories])
 
   const loadAnalytics = useCallback(async () => {
     const now = new Date()

--- a/frontend/packages/api-client/src/read.ts
+++ b/frontend/packages/api-client/src/read.ts
@@ -109,6 +109,7 @@ export async function fetchWorkspaceTransactions(
     txSyncId?: string
     tagSyncId?: string
     categorySyncId?: string
+    categorySyncIds?: string[]
     accountSyncId?: string
     /** 金额下限(含),按 abs 比较 */
     amountMin?: number
@@ -131,6 +132,9 @@ export async function fetchWorkspaceTransactions(
   if (options?.txSyncId) query.set('tx_sync_id', options.txSyncId)
   if (options?.tagSyncId) query.set('tag_sync_id', options.tagSyncId)
   if (options?.categorySyncId) query.set('category_sync_id', options.categorySyncId)
+  if (options?.categorySyncIds?.length) {
+    for (const id of options.categorySyncIds) query.append('category_sync_ids', id)
+  }
   if (options?.accountSyncId) query.set('account_sync_id', options.accountSyncId)
   if (typeof options?.amountMin === 'number') query.set('amount_min', `${options.amountMin}`)
   if (typeof options?.amountMax === 'number') query.set('amount_max', `${options.amountMax}`)

--- a/frontend/packages/api-client/src/types.ts
+++ b/frontend/packages/api-client/src/types.ts
@@ -228,6 +228,7 @@ export type ReadCategory = {
   icon_cloud_file_id?: string | null
   icon_cloud_sha256?: string | null
   parent_name: string | null
+  parent_sync_id?: string | null
   last_change_id: number
   ledger_id?: string | null
   ledger_name?: string | null

--- a/frontend/packages/web-features/src/lib/budgetUsage.ts
+++ b/frontend/packages/web-features/src/lib/budgetUsage.ts
@@ -2,6 +2,7 @@ import {
   fetchReadBudgets,
   fetchWorkspaceTransactions,
   type ReadBudget,
+  type WorkspaceCategory,
 } from '@beecount/api-client'
 
 import type { BudgetUsage } from '../features/BudgetsPanel'
@@ -37,9 +38,27 @@ export type BudgetsWithUsage = {
 }
 
 /**
+ * Collect parent category id + all child category ids for budget usage query.
+ * When a budget targets a parent category, transactions under any of its
+ * subcategories should also count toward the budget.
+ */
+function collectCategorySyncIds(
+  budgetCategoryId: string,
+  categories: readonly WorkspaceCategory[],
+): string[] {
+  const ids = [budgetCategoryId]
+  for (const cat of categories) {
+    if (cat.parent_sync_id === budgetCategoryId) {
+      ids.push(cat.id)
+    }
+  }
+  return ids
+}
+
+/**
  * 拉指定账本的 budgets + 每个 budget 当前周期的 used。
  * - total budget:全部 expense 累加(指定 ledger 范围内)
- * - category budget:按 category_sync_id 过滤
+ * - category budget:按 category_sync_id 过滤,含子分类交易
  *
  * 每个 budget 独立 fetch 期内 tx — 跟 mobile repository.getBudgetUsage
  * per-budget 模式一致。budgets 数量通常很少(1 个 total + 几个 category),
@@ -51,6 +70,7 @@ export type BudgetsWithUsage = {
 export async function fetchBudgetsWithUsage(
   token: string,
   ledgerId: string,
+  categories: readonly WorkspaceCategory[],
 ): Promise<BudgetsWithUsage> {
   const budgets = await fetchReadBudgets(token, ledgerId)
   if (budgets.length === 0) {
@@ -62,12 +82,13 @@ export async function fetchBudgetsWithUsage(
       try {
         const startDay = Math.max(1, Math.min(28, Number(b.start_day || 1)))
         const { start, end } = currentMonthRange(startDay)
-        const categorySyncId =
-          b.type === 'category' ? b.category_id || undefined : undefined
         const page = await fetchWorkspaceTransactions(token, {
           ledgerId,
           txType: 'expense',
-          categorySyncId,
+          categorySyncIds:
+            b.type === 'category' && b.category_id
+              ? collectCategorySyncIds(b.category_id, categories)
+              : undefined,
           dateFrom: start.toISOString(),
           dateTo: end.toISOString(),
           limit: 1000,

--- a/src/routers/read/ledgers.py
+++ b/src/routers/read/ledgers.py
@@ -432,6 +432,7 @@ def list_categories(
             icon_cloud_file_id=row.icon_cloud_file_id,
             icon_cloud_sha256=row.icon_cloud_sha256,
             parent_name=row.parent_name,
+            parent_sync_id=row.parent_sync_id,
             last_change_id=source_change_id,
             ledger_id=ledger.external_id,
             ledger_name=ledger_name,

--- a/src/routers/read/workspace.py
+++ b/src/routers/read/workspace.py
@@ -20,6 +20,7 @@ def list_workspace_transactions(
     tx_sync_id: str | None = Query(default=None, description="按 tx 自身 syncId 精确过滤(用于 admin/integrity 跳到具体交易)"),
     tag_sync_id: str | None = Query(default=None, description="按 tag syncId 精确过滤,不走模糊搜索"),
     category_sync_id: str | None = Query(default=None, description="按 category syncId 精确过滤"),
+    category_sync_ids: list[str] | None = Query(default=None, description="按 category syncId 集合过滤(repeated query param);传入则忽略 category_sync_id"),
     account_sync_id: str | None = Query(default=None, description="按 account syncId 精确过滤(含 from/to)"),
     amount_min: float | None = Query(default=None, description="金额下限(含)。按 abs(amount) 比较以兼容 expense 负值"),
     amount_max: float | None = Query(default=None, description="金额上限(含)"),
@@ -86,7 +87,9 @@ def list_workspace_transactions(
         query = query.where(
             ReadTxProjection.tag_sync_ids_json.like(f'%"{tag_sync_id}"%')
         )
-    if category_sync_id:
+    if category_sync_ids:
+        query = query.where(ReadTxProjection.category_sync_id.in_(category_sync_ids))
+    elif category_sync_id:
         query = query.where(ReadTxProjection.category_sync_id == category_sync_id)
     if account_sync_id:
         query = query.where(or_(
@@ -280,6 +283,7 @@ def export_workspace_transactions_csv(
     ),
     tag_sync_id: str | None = Query(default=None),
     category_sync_id: str | None = Query(default=None),
+    category_sync_ids: list[str] | None = Query(default=None, description="按 category syncId 集合过滤(repeated query param);传入则忽略 category_sync_id"),
     account_sync_id: str | None = Query(default=None),
     amount_min: float | None = Query(default=None),
     amount_max: float | None = Query(default=None),
@@ -397,7 +401,9 @@ def export_workspace_transactions_csv(
             query = query.where(
                 ReadTxProjection.tag_sync_ids_json.like(f'%"{tag_sync_id}"%')
             )
-        if category_sync_id:
+        if category_sync_ids:
+            query = query.where(ReadTxProjection.category_sync_id.in_(category_sync_ids))
+        elif category_sync_id:
             query = query.where(ReadTxProjection.category_sync_id == category_sync_id)
         if account_sync_id:
             query = query.where(or_(
@@ -800,6 +806,7 @@ def list_workspace_categories(
                 icon_cloud_file_id=cat.icon_cloud_file_id,
                 icon_cloud_sha256=cat.icon_cloud_sha256,
                 parent_name=cat.parent_name,
+                parent_sync_id=cat.parent_sync_id,
                 last_change_id=cat_last_change_id,
                 ledger_id="",
                 ledger_name="",

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -563,6 +563,7 @@ class ReadCategoryOut(BaseModel):
     icon_cloud_file_id: str | None = None
     icon_cloud_sha256: str | None = None
     parent_name: str | None
+    parent_sync_id: str | None = None
     last_change_id: int
     ledger_id: str | None = None
     ledger_name: str | None = None


### PR DESCRIPTION
## 关联 Issue

Closes #15

## 问题描述

给父分类（如吃喝）设置了分类预算 1000 元后，在其子分类（如吃、喝）下新增交易，父分类的预算消耗不会计入子分类的交易支出。只有直接关联父分类的交易才会被计入。

## 根因

前端 `budgetUsage.ts` 的 `fetchBudgetsWithUsage` 在计算分类预算使用量时，用 `categorySyncId` 精确匹配预算分类的 ID。但交易关联的是子分类的 `sync_id`，不是父分类的，所以匹配不上。

后端 `workspace.py` 的交易查询接口也只支持单个 `category_sync_id` 精确匹配，无法一次查询多个分类 ID。

## 修改内容

### 后端（3 个文件）
- `src/routers/read/workspace.py`：新增 `category_sync_ids` 多值参数（repeated query param），支持 `IN` 查询。在 `list_workspace_transactions` 和 `export_workspace_transactions_csv` 两处都加了，同时保持 `category_sync_id` 单值参数的向后兼容。
- `src/routers/read/ledgers.py`：`list_categories` 返回 `parent_sync_id` 字段（上游 0013 migration 已有此列）。
- `src/routers/read/workspace.py`：`list_workspace_categories` 同样返回 `parent_sync_id`。
- `src/schemas.py`：`ReadCategoryOut` 新增 `parent_sync_id` 字段。

### 前端（4 个文件）
- `packages/api-client/src/types.ts`：`ReadCategory` 类型加 `parent_sync_id`。
- `packages/api-client/src/read.ts`：`fetchWorkspaceTransactions` 支持 `categorySyncIds: string[]` 参数。
- `packages/web-features/src/lib/budgetUsage.ts`：新增 `collectCategorySyncIds()` 函数，收集父分类 + 所有 `parent_sync_id` 指向父分类的子分类 ID，一起传给后端查询。
- `apps/web/src/pages/sections/OverviewPage.tsx`：把 `categories` 列表传给 `fetchBudgetsWithUsage`。

## 测试

- 后端 288 个测试全部通过 ✅
- 改动仅涉及 API 读层和前端计算层，未动 sync/projection/schema 迁移