### PR TITLE
feat: allow read API scoped PATs

### DIFF
--- a/docs/MCP.en.md
+++ b/docs/MCP.en.md
@@ -138,7 +138,7 @@ Once connected, ask the LLM:
 | Message back-channel | `https://your-domain.com/api/v1/mcp/messages/` |
 | Auth | `Authorization: Bearer bcmcp_…` (PAT) |
 
-PAT and access tokens are strictly partitioned: **PATs only work against `/api/v1/mcp/*`** — every other API rejects PATs with 403. Conversely, regular access tokens cannot call MCP endpoints.
+PATs and access tokens are strictly partitioned: **MCP-scoped PATs only work against `/api/v1/mcp/*`**. For external read-only sync clients, create a separate PAT with the `read:api` scope for `/api/v1/read/*`. Conversely, regular access tokens cannot call MCP endpoints.
 
 ---
 
@@ -149,9 +149,9 @@ PAT and access tokens are strictly partitioned: **PATs only work against `/api/v
 | Token storage | Server stores `sha256` hash only, constant-time compare; plaintext returned exactly once at creation |
 | Token deletion | One-shot physical delete — the row leaves the DB and the token becomes invalid immediately |
 | Token expiration | Optional at creation; expired tokens get 401 |
-| Scope separation | `mcp:read` / `mcp:write` are independently selected; read-only tokens cannot be escalated |
+| Scope separation | `mcp:read` / `mcp:write` / `read:api` are independently selected; read-only tokens cannot be escalated |
 | Destructive ops | `delete_transaction` requires `confirm=true`; the first call returns a "needs confirmation" placeholder and the LLM must ask the user first |
-| Boundary | PATs cannot call regular `/api/v1/*` endpoints — only MCP tools |
+| Boundary | MCP PATs cannot call regular `/api/v1/*` endpoints; `read:api` PATs can only call `/api/v1/read/*` |
 | Audit | Every PAT use bumps `last_used_at` + `last_used_ip`, visible in the web settings page |
 
 **If a PAT leaks**: delete it from the web settings page immediately, then check `last_used_ip` for suspicious sources.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -136,7 +136,7 @@ LLM 客户端连上之后:
 | 消息回信道 | `https://your-domain.com/api/v1/mcp/messages/` |
 | 鉴权 | `Authorization: Bearer bcmcp_…`(PAT) |
 
-PAT 跟 access token 严格分流:**PAT 只能用在 `/api/v1/mcp/*`**,所有其他 API 接收 PAT 都返回 403。同理 access token 不能用来调 MCP endpoint。
+PAT 跟 access token 严格分流:**MCP scope PAT 只能用在 `/api/v1/mcp/*`**；如需外部只读同步器调用 `/api/v1/read/*`，请创建单独的 `read:api` scope PAT。同理 access token 不能用来调 MCP endpoint。
 
 ---
 
@@ -147,9 +147,9 @@ PAT 跟 access token 严格分流:**PAT 只能用在 `/api/v1/mcp/*`**,所有其
 | Token 存储 | `sha256` 哈希 + `hmac.compare_digest` 常数时间比较,**明文只在创建时返一次** |
 | Token 删除 | 一键物理删除,该行从 DB 移除,token 立即失效 |
 | Token 过期 | 创建时可设过期日,过期后 401 |
-| Scope 分离 | `mcp:read` / `mcp:write` 独立勾选;只 read 不会被升权成 write |
+| Scope 分离 | `mcp:read` / `mcp:write` / `read:api` 独立勾选;只 read 不会被升权成 write |
 | 危险操作 | `delete_transaction` 必须传 `confirm=true`,首次调用返"待确认"占位符,LLM 必须跟用户确认后再调一次 |
-| 写权限隔离 | PAT 不能调常规 `/api/v1/*` endpoint,只能调 MCP tool |
+| 写权限隔离 | MCP PAT 不能调常规 `/api/v1/*` endpoint；`read:api` PAT 只能调 `/api/v1/read/*` |
 | 审计 | 每次 PAT 使用都 bump `last_used_at` + `last_used_ip`,Web 设置页可看 |
 
 **如果 PAT 泄露**:立即去 Web 设置页删除该 token;同时检查 `last_used_ip` 是否有异常来源。

--- a/src/deps.py
+++ b/src/deps.py
@@ -12,6 +12,7 @@ from .ledger_access import get_accessible_ledger_by_external_id
 from .models import Device, Ledger, PersonalAccessToken, User
 from .security import (
     PAT_PREFIX,
+    SCOPE_READ_API,
     decode_token,
     looks_like_pat,
     verify_pat_hash,
@@ -254,6 +255,52 @@ def require_any_scopes(*required_any: str) -> Callable:
     return _dep
 
 
+def require_read_api_scopes(*required_any_jwt: str) -> Callable:
+    """Read API auth boundary.
+
+    JWT callers keep the existing web/app scope behavior. Long-lived PAT callers
+    are accepted only when explicitly scoped for read API access.
+    """
+    required_any_jwt_set = set(required_any_jwt)
+
+    def _dep(
+        request: Request,
+        token: str = Depends(oauth2_scheme),
+        db: Session = Depends(get_db),
+    ) -> set[str]:
+        if looks_like_pat(token):
+            user, scopes = _resolve_pat(token, request, db)
+            if SCOPE_READ_API not in scopes:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="PAT missing required scope: read:api",
+                )
+            request.state.bc_user = user
+            request.state.bc_auth_kind = "pat"
+            return scopes
+
+        try:
+            payload = decode_token(token)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+            ) from exc
+        if payload.get("type") != "access":
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token type")
+        request.state.bc_jwt_payload = payload
+        request.state.bc_auth_kind = "jwt"
+        scopes_raw = payload.get("scopes", [])
+        scopes = {str(scope) for scope in scopes_raw if scope} if isinstance(scopes_raw, list) else set()
+        if required_any_jwt_set and required_any_jwt_set.isdisjoint(scopes):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Insufficient scope",
+            )
+        return scopes
+
+    return _dep
+
+
 def require_ledger_role(*roles: str) -> Callable:
     role_set = set(roles)
 
@@ -289,16 +336,16 @@ def get_current_user(
 ) -> User:
     """常规 endpoint 取 user。**PAT 在这里被显式拒绝** — PAT 走 `get_mcp_user`。
     """
+    cached = getattr(request.state, "bc_user", None)
+    if isinstance(cached, User):
+        return cached
+
     # PAT 不允许走常规 API
     if looks_like_pat(token):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="PAT can only be used for MCP endpoints",
         )
-
-    cached = getattr(request.state, "bc_user", None)
-    if isinstance(cached, User):
-        return cached
 
     try:
         payload = decode_token(token)

--- a/src/routers/pats.py
+++ b/src/routers/pats.py
@@ -1,6 +1,6 @@
 """Personal Access Token (PAT) 管理 endpoint。
 
-PAT 是给 MCP / 外部 LLM 客户端用的长期 token。详见 .docs/mcp-server-design.md。
+PAT 是给 MCP / 外部 LLM 客户端 / 只读同步器用的长期 token。详见 .docs/mcp-server-design.md。
 
 路由设计:
   - 创建 / 列出 / 撤销:必须用 access token(JWT)调用,**不能用 PAT 自己创自己**
@@ -29,6 +29,7 @@ from ..security import (
     SCOPE_APP_WRITE,
     SCOPE_MCP_READ,
     SCOPE_MCP_WRITE,
+    SCOPE_READ_API,
     SCOPE_WEB_READ,
     SCOPE_WEB_WRITE,
     generate_pat,
@@ -55,14 +56,14 @@ def _require_jwt_only(current_user: User = Depends(get_current_user)) -> User:
     return current_user
 
 
-_ScopeName = Literal["mcp:read", "mcp:write"]
+_ScopeName = Literal["mcp:read", "mcp:write", "read:api"]
 
 
 class PatCreateRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=128, description="给这个 token 起的标识名,如 'Claude Desktop'")
     scopes: list[_ScopeName] = Field(
         default_factory=lambda: ["mcp:read"],
-        description="授权范围。mcp:read 让 LLM 查数据,mcp:write 让 LLM 改数据。",
+        description="授权范围。mcp:read 让 LLM 查数据,mcp:write 让 LLM 改数据,read:api 让外部只读同步器调用 /read/*。",
     )
     expires_in_days: int | None = Field(
         default=90,
@@ -135,7 +136,7 @@ def create_pat(
             detail="At least one scope required",
         )
     # 校验 scope 合法性 — Pydantic Literal 已经管了,这里 belt-and-suspenders
-    allowed = {SCOPE_MCP_READ, SCOPE_MCP_WRITE}
+    allowed = {SCOPE_MCP_READ, SCOPE_MCP_WRITE, SCOPE_READ_API}
     bad = [s for s in req.scopes if s not in allowed]
     if bad:
         raise HTTPException(
@@ -249,7 +250,7 @@ def update_pat(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail="At least one scope required",
             )
-        allowed = {SCOPE_MCP_READ, SCOPE_MCP_WRITE}
+        allowed = {SCOPE_MCP_READ, SCOPE_MCP_WRITE, SCOPE_READ_API}
         bad = [s for s in req.scopes if s not in allowed]
         if bad:
             raise HTTPException(

--- a/src/routers/read/_shared.py
+++ b/src/routers/read/_shared.py
@@ -24,7 +24,7 @@ from sqlalchemy.orm import Session
 
 from ...config import get_settings
 from ...database import get_db
-from ...deps import get_current_user, require_any_scopes, require_scopes
+from ...deps import get_current_user, require_any_scopes, require_read_api_scopes, require_scopes
 from ...ledger_access import (
     get_accessible_ledger_by_external_id,
 )
@@ -72,9 +72,9 @@ from ... import snapshot_cache
 router = APIRouter()
 settings = get_settings()
 _READ_SCOPE_DEP = (
-    require_any_scopes(SCOPE_WEB_READ, SCOPE_APP_WRITE)
+    require_read_api_scopes(SCOPE_WEB_READ, SCOPE_APP_WRITE)
     if settings.allow_app_rw_scopes
-    else require_scopes(SCOPE_WEB_READ)
+    else require_read_api_scopes(SCOPE_WEB_READ)
 )
 
 

--- a/src/security.py
+++ b/src/security.py
@@ -16,6 +16,7 @@ SCOPE_APP_WRITE = "app_write"
 SCOPE_WEB_READ = "web_read"
 SCOPE_WEB_WRITE = "web_write"
 SCOPE_OPS_WRITE = "ops_write"
+SCOPE_READ_API = "read:api"
 # MCP 专用 scope。PAT 创建时用户选这两个之一或两个都选。MCP server 的
 # read tools 要求 `mcp:read`,write tools 要求 `mcp:write`。详见 .docs/mcp-
 # server-design.md。

--- a/tests/test_pats_api.py
+++ b/tests/test_pats_api.py
@@ -3,7 +3,7 @@
 覆盖:
 1. 创建 / 列表 / 撤销
 2. 列表只返 prefix,不返明文
-3. PAT 不能调常规 API endpoint (`/profile/me` 等) — 必须 403
+3. PAT 默认不能调常规 API endpoint；只有 read:api PAT 能调 `/read/*`
 4. JWT access token 不能调 MCP endpoint (`/api/v1/mcp/*`) — 必须 403
 5. 无 auth 头 / 错 PAT 调 MCP — 必须 401
 6. PAT 自己不能创新 PAT — 防止泄露后自我续期(由 _require_jwt_only 保证)
@@ -130,6 +130,25 @@ def test_create_pat_rejects_invalid_scope(monkeypatch) -> None:
         )
         # Pydantic Literal 校验失败
         assert res.status_code == 422
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_create_pat_allows_read_api_scope(monkeypatch) -> None:
+    client = _make_client(monkeypatch)
+    try:
+        user = _register(client)
+        token = user["access_token"]
+        res = client.post(
+            "/api/v1/profile/pats",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"name": "Radar sync", "scopes": ["read:api"], "expires_in_days": None},
+        )
+        assert res.status_code == 201, res.text
+        body = res.json()
+        assert body["token"].startswith("bcmcp_")
+        assert body["scopes"] == ["read:api"]
+        assert body["expires_at"] is None
     finally:
         app.dependency_overrides.clear()
 
@@ -277,7 +296,7 @@ def test_user_a_cannot_see_user_b_pat(monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 严格分流:PAT 不能调常规 API
+# 严格分流:PAT 默认不能调常规 API；read:api 只放行 /read/*
 # ---------------------------------------------------------------------------
 
 
@@ -301,6 +320,79 @@ def test_pat_cannot_call_profile_me(monkeypatch) -> None:
         )
         assert res.status_code == 403
         assert "PAT" in res.json().get("detail", "")
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_read_api_pat_can_call_read_endpoints(monkeypatch) -> None:
+    client = _make_client(monkeypatch)
+    try:
+        user = _register(client)
+        token = user["access_token"]
+        create_res = client.post(
+            "/api/v1/profile/pats",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"name": "Radar sync", "scopes": ["read:api"], "expires_in_days": None},
+        )
+        assert create_res.status_code == 201, create_res.text
+        pat_plaintext = create_res.json()["token"]
+
+        res = client.get(
+            "/api/v1/read/ledgers",
+            headers={"Authorization": f"Bearer {pat_plaintext}"},
+        )
+        assert res.status_code == 200, res.text
+        assert res.json() == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_mcp_pat_cannot_call_read_api(monkeypatch) -> None:
+    client = _make_client(monkeypatch)
+    try:
+        user = _register(client)
+        token = user["access_token"]
+        create_res = client.post(
+            "/api/v1/profile/pats",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"name": "MCP only", "scopes": ["mcp:read"]},
+        )
+        pat_plaintext = create_res.json()["token"]
+
+        res = client.get(
+            "/api/v1/read/ledgers",
+            headers={"Authorization": f"Bearer {pat_plaintext}"},
+        )
+        assert res.status_code == 403
+        assert "read:api" in res.json().get("detail", "")
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_read_api_pat_cannot_call_write_or_profile(monkeypatch) -> None:
+    client = _make_client(monkeypatch)
+    try:
+        user = _register(client)
+        token = user["access_token"]
+        create_res = client.post(
+            "/api/v1/profile/pats",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"name": "Radar sync", "scopes": ["read:api"], "expires_in_days": None},
+        )
+        pat_plaintext = create_res.json()["token"]
+
+        profile_res = client.get(
+            "/api/v1/profile/me",
+            headers={"Authorization": f"Bearer {pat_plaintext}"},
+        )
+        assert profile_res.status_code == 403
+
+        write_res = client.post(
+            "/api/v1/write/ledgers/ledger-1/accounts",
+            headers={"Authorization": f"Bearer {pat_plaintext}"},
+            json={"base_change_id": 0, "name": "Cash", "account_type": "cash"},
+        )
+        assert write_res.status_code == 403
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- add a dedicated `read:api` PAT scope for long-lived read API clients
- allow `/api/v1/read/*` to authenticate with `read:api` PATs while keeping MCP and write/profile boundaries intact
- update PAT docs and tests for the new boundary

## Tests
- `uv run --with-requirements requirements.txt pytest tests/test_pats_api.py tests/test_app_scope_guardrail.py tests/test_tx_read_id_resolution.py -q`