### PR TITLE
fix(account): 信用卡已用额度走 balance,修「转入额度不恢复」(#26)

### DIFF
--- a/frontend/apps/web/src/components/dialogs/AccountDetailDialog.tsx
+++ b/frontend/apps/web/src/components/dialogs/AccountDetailDialog.tsx
@@ -159,13 +159,20 @@ function AccountCardInfo({
   const billingDay = isCreditCard ? account.billing_day : null
   const paymentDueDay = isCreditCard ? account.payment_due_day : null
 
-  // 信用卡已用额度 = 累计支出 - 累计收入(还款)。剩余额度 = limit - used。
+  // 信用卡已用额度 = -balance(余额为负表示欠款),剩余额度 = limit - used。
   // 这是粗略估算 — 没考虑账单周期,只看终身累计。但作为"大致还能刷多少"
   // 的信号已经够用,后续要精确版本应该按 billing_day 分账期算。
+  //
+  // 为什么用 balance 而不是 expense_total - income_total:后者会漏掉"储蓄卡
+  // 转账到信用卡还款"这种 transfer-in 操作 —— 转账既不是 expense 也不是
+  // income,只在 backend 的 balance 计算里被加回去(workspace.py 的
+  // transfer_to bucket)。balance 已经统一包含初始余额 + 全部 income /
+  // expense / transfer-in / transfer-out,跟 mobile 端
+  // `getCreditCardUsedAmount` (balance < 0 ? -balance : 0) 完全一致。
+  // 修复 issue #26:储蓄卡转账到信用卡额度没恢复。
+  const balance = account.balance ?? account.initial_balance ?? 0
   const used =
-    typeof creditLimit === 'number'
-      ? Math.max(0, (account.expense_total ?? 0) - (account.income_total ?? 0))
-      : null
+    typeof creditLimit === 'number' ? Math.max(0, -balance) : null
   const remaining =
     typeof creditLimit === 'number' && used !== null
       ? Math.max(0, creditLimit - used)


### PR DESCRIPTION
## Summary
修 issue #26 用户反馈:储蓄卡转账到信用卡后,信用卡额度没恢复。Mobile 端逻辑一直是对的,只是 Web 端展示算错了。

## 根因
\`AccountDetailDialog.tsx\` 算信用卡已用额度时用的是 \`expense_total - income_total\`,但 \`expense_total\` / \`income_total\` 这两个字段只统计 income/expense 交易,**不包含 transfer**。

所以 「储蓄卡 → 信用卡」 这种 transfer-in 操作对信用卡来说只反映在 \`balance\` 上(backend 的 \`workspace.py\` 在算 balance 时有 transfer_to bucket 处理),但 expense_total/income_total 都没变 → 前端算出来的 used 就没恢复。

## 修复
改成跟 mobile 端 \`getCreditCardUsedAmount\` 一致的逻辑:
\`\`\`ts
const balance = account.balance ?? account.initial_balance ?? 0
const used = Math.max(0, -balance)
const remaining = Math.max(0, creditLimit - used)
\`\`\`

\`balance\` 已经统一包含初始余额 + 全部 income / expense / transfer-in / transfer-out,直接用即可。

## 验证场景
- 信用卡限额 1000,消费 100 → \`balance = -100\`
  - 修复前 used = \`100 - 0 = 100\` ✓
  - 修复后 used = \`-(-100) = 100\` ✓
- 储蓄卡转账还 100 到信用卡 → \`balance = 0\`(transfer-in +100)
  - 修复前 used = \`100 - 0 = 100\` ❌(没恢复)
  - 修复后 used = \`-(0) = 0\` ✓

## Test plan
- [x] \`pnpm --filter @beecount/web build\` 通过
- [x] 类型检查通过
- [ ] 部署后,信用卡消费 100 → 储蓄卡转账 100 到信用卡 → 信用卡详情页「已用额度」显示 0,「可用额度」恢复满
- [ ] 仅消费没还款的信用卡仍正确显示 used / remaining(不应被这次改动影响)

Fixes #26