### PR TITLE
fix(sync): 共享账本 Editor 删 tx 清理附件 + entity delete 自压缩 sync_changes

### DIFF
--- a/src/projection.py
+++ b/src/projection.py
@@ -766,6 +766,102 @@ def _fileid_still_referenced(db: Session, *, user_id: str, file_id: str) -> bool
     return bool(cat_hit)
 
 
+def _fileid_still_referenced_in_ledger(
+    db: Session, *, ledger_id: str, file_id: str,
+) -> bool:
+    """某个 AttachmentFile 在该 ledger 下任何 user 的 tx projection 还有引用吗?
+
+    跟 [_fileid_still_referenced] 不同之处:**按 ledger_id 过滤,不按 user_id**。
+
+    共享账本场景下 tx 创建人(Editor)上传的 attachment 在 `attachment_files` 表里
+    user_id = Editor,但 `read_tx_projection` 里行可能挂在 ledger owner 的 user_id 下。
+    `_delete_tx` 的 GC 路径如果用 user_id 过滤就会漏 — 这里改按 ledger_id 扫,任何
+    user 的 projection 行只要还引用这个 fileId,都算"被引用",不能 GC。
+
+    category icon 不是 ledger-scope,继续走原 [_fileid_still_referenced]。
+    """
+    pat_no_space = f'%"cloudFileId":"{file_id}"%'
+    pat_with_space = f'%"cloudFileId": "{file_id}"%'
+    tx_hit = db.scalar(
+        select(func.count())
+        .select_from(ReadTxProjection)
+        .where(
+            ReadTxProjection.ledger_id == ledger_id,
+            or_(
+                ReadTxProjection.attachments_json.like(pat_no_space),
+                ReadTxProjection.attachments_json.like(pat_with_space),
+            ),
+        )
+    )
+    return bool(tx_hit)
+
+
+def gc_orphan_attachments_for_ledger(
+    db: Session,
+    *,
+    ledger_id: str,
+    file_ids: Iterable[str | None],
+) -> int:
+    """对给定 fileId 集合,若该 ledger 下任何 user 的 tx projection 都无引用 →
+    删 AttachmentFile 行 + unlink 物理文件。返回实际清掉的条数。
+
+    跟 [gc_orphan_attachments] 同款契约(调用前 projection 必须先删),区别是
+    **scope 是 ledger 而不是 user**:
+
+    - **引用检查**走 [_fileid_still_referenced_in_ledger](扫所有 user 在本 ledger
+      的 projection,不限 user_id)
+    - **DELETE 时按 ledger_id 过滤**,不按 user_id,所以 Editor 上传的附件(user_id
+      = Editor)也能被 Owner-发起的 delete 路径正确清理。
+
+    使用场景:**ledger-scope 实体的 delete handler**(tx)。
+    category icon / 其它 user-scope 路径继续用 [gc_orphan_attachments]。
+    """
+    cleaned = 0
+    seen: set[str] = set()
+    for fid in file_ids:
+        if not fid:
+            continue
+        file_id = fid.strip()
+        if not file_id or file_id in seen:
+            continue
+        seen.add(file_id)
+
+        if _fileid_still_referenced_in_ledger(
+            db, ledger_id=ledger_id, file_id=file_id,
+        ):
+            continue
+
+        att = db.scalar(
+            select(AttachmentFile).where(
+                AttachmentFile.id == file_id,
+                AttachmentFile.ledger_id == ledger_id,
+            )
+        )
+        if att is None:
+            continue
+
+        storage_path = att.storage_path
+        db.delete(att)
+
+        try:
+            p = Path(storage_path)
+            if p.exists():
+                p.unlink()
+        except OSError as exc:
+            logger.warning(
+                "attachment gc unlink failed ledger=%s file=%s path=%s err=%s",
+                ledger_id, file_id, storage_path, exc,
+            )
+
+        cleaned += 1
+
+    if cleaned:
+        logger.info(
+            "attachment gc ledger=%s cleaned=%d", ledger_id, cleaned,
+        )
+    return cleaned
+
+
 def gc_orphan_attachments(
     db: Session,
     *,

--- a/src/sync_applier.py
+++ b/src/sync_applier.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 import json
 from typing import Any, Callable, Optional
 
-from sqlalchemy import select
+from sqlalchemy import delete as sa_delete, select
 from sqlalchemy.orm import Session
 
 from . import projection
@@ -213,6 +213,42 @@ _LEDGER_UPSERT_DISPATCH: dict[str, Callable] = {
 # category 删除时附带 GC icon 附件(同样 user_id scope)。
 
 
+def _compact_entity_upsert_events(
+    db: Session,
+    *,
+    user_id: str,
+    entity_type: str,
+    entity_sync_id: str,
+) -> int:
+    """实体被删除后,清掉该 (user_id, entity_type, entity_sync_id) 的全部 **upsert**
+    sync_changes 历史,**保留 delete 事件本身**。
+
+    背景:sync_changes 一般是 append-only event log,不裸 DELETE(防止 projection
+    跟 log 漂移,见 21136 案例)。但**实体彻底下线**的场景下,所有 upsert 事件都已
+    没有价值:
+      - projection 已经把该实体的行删了 → 没人会再引用任何 source_change_id
+      - 其它设备 cursor 落后时,只看到 delete event 也能正确处理(apply 路径
+        `if (existingId == null) return;` 是 idempotent no-op,见
+        sync_engine_apply.dart::_applyTransactionChange)
+      - delete event 本身**保留**,确保 cursor 落后的设备能 apply delete 把本地
+        副本删干净
+
+    所以"删 entity 时连带清掉它的 upsert 历史"是契约的**合理例外**,跟"projection
+    漂移"那种裸 DELETE 不一样。
+
+    返回清掉的 row 数。
+    """
+    result = db.execute(
+        sa_delete(SyncChange).where(
+            SyncChange.user_id == user_id,
+            SyncChange.entity_type == entity_type,
+            SyncChange.entity_sync_id == entity_sync_id,
+            SyncChange.action != "delete",
+        )
+    )
+    return result.rowcount or 0
+
+
 def _delete_tx(db: Session, ledger_id: str, sync_id: str, user_id: str) -> None:
     # 先收集附件 fileId(删行后 attachments_json 就没了)再删 tx,然后 GC
     # 孤立附件。共享引用(同图多 tx)的会自动保留。
@@ -220,8 +256,17 @@ def _delete_tx(db: Session, ledger_id: str, sync_id: str, user_id: str) -> None:
         db, ledger_id=ledger_id, sync_id=sync_id,
     )
     projection.delete_tx(db, ledger_id=ledger_id, sync_id=sync_id)
-    projection.gc_orphan_attachments(
-        db, user_id=user_id, file_ids=tx_file_ids,
+    # 共享账本场景:attachment.user_id 可能是 Editor 而 SyncChange.user_id 是
+    # ledger owner,GC 必须按 ledger_id scope 而不是 user_id —— 否则 Editor 上传
+    # 的附件永远被静默跳过留作孤儿。详见 projection.gc_orphan_attachments_for_ledger
+    # 的 doc。
+    projection.gc_orphan_attachments_for_ledger(
+        db, ledger_id=ledger_id, file_ids=tx_file_ids,
+    )
+    # 实体彻底下线,清 upsert 历史(详见 _compact_entity_upsert_events)
+    _compact_entity_upsert_events(
+        db, user_id=user_id, entity_type="transaction",
+        entity_sync_id=sync_id,
     )
 
 
@@ -231,21 +276,46 @@ def _delete_user_category(db: Session, user_id: str, sync_id: str) -> None:
         db, user_id=user_id, sync_id=sync_id,
     )
     projection.delete_category(db, user_id=user_id, sync_id=sync_id)
+    # category icon 是 user-scope,继续走 gc_orphan_attachments(user_id)
     projection.gc_orphan_attachments(
         db, user_id=user_id, file_ids=cat_file_ids,
+    )
+    _compact_entity_upsert_events(
+        db, user_id=user_id, entity_type="category", entity_sync_id=sync_id,
+    )
+
+
+def _delete_budget(db: Session, ledger_id: str, sync_id: str, user_id: str) -> None:
+    projection.delete_budget(db, ledger_id=ledger_id, sync_id=sync_id)
+    _compact_entity_upsert_events(
+        db, user_id=user_id, entity_type="budget", entity_sync_id=sync_id,
+    )
+
+
+def _delete_user_account(db: Session, user_id: str, sync_id: str) -> None:
+    projection.delete_account(db, user_id=user_id, sync_id=sync_id)
+    _compact_entity_upsert_events(
+        db, user_id=user_id, entity_type="account", entity_sync_id=sync_id,
+    )
+
+
+def _delete_user_tag(db: Session, user_id: str, sync_id: str) -> None:
+    projection.delete_tag(db, user_id=user_id, sync_id=sync_id)
+    _compact_entity_upsert_events(
+        db, user_id=user_id, entity_type="tag", entity_sync_id=sync_id,
     )
 
 
 _LEDGER_DELETE_DISPATCH: dict[str, Callable[[Session, str, str, str], None]] = {
     "transaction": _delete_tx,
-    "budget": lambda db, lid, sid, uid: projection.delete_budget(db, ledger_id=lid, sync_id=sid),
+    "budget": _delete_budget,
 }
 
 
 _USER_DELETE_DISPATCH: dict[str, Callable[[Session, str, str], None]] = {
-    "account": lambda db, uid, sid: projection.delete_account(db, user_id=uid, sync_id=sid),
+    "account": _delete_user_account,
     "category": _delete_user_category,
-    "tag": lambda db, uid, sid: projection.delete_tag(db, user_id=uid, sync_id=sid),
+    "tag": _delete_user_tag,
 }
 
 

--- a/tests/test_ai_parse_tx.py
+++ b/tests/test_ai_parse_tx.py
@@ -342,9 +342,18 @@ def test_batch_create_with_ai_tag_and_extra_tag(monkeypatch):
         app.dependency_overrides.clear()
 
 
-def test_batch_create_with_image_attachment(monkeypatch):
+def test_batch_create_with_image_attachment(monkeypatch, tmp_path):
     """attach_image_id → server 转 attachment + 关联到所有 tx。"""
     from src.services.ai.image_cache import store_image
+    from src import config
+
+    # 把 attachment_storage_dir 重定向到 pytest tmp_path,避免 test 跑完留下
+    # 13B 的 "fakejpegbytes" 文件污染 dev 的 ./data/attachments/(scanner 会
+    # 把它当成磁盘孤儿报上来)。tmp_path 在 test session 结束自动清理。
+    settings = config.get_settings()
+    monkeypatch.setattr(
+        settings, "attachment_storage_dir", str(tmp_path / "attachments"),
+    )
 
     client = _make_client()
     try:

--- a/tests/test_shared_ledger_delete_cleanup.py
+++ b/tests/test_shared_ledger_delete_cleanup.py
@@ -1,0 +1,538 @@
+"""共享账本 Editor 删 tx 的清理路径专项单测。
+
+锁定两个相关行为:
+
+1. **附件 GC 按 ledger-scope** —— 共享账本里 Editor 上传的附件 `user_id = Editor`,
+   但 ledger owner-scope SyncChange.user_id = Owner;用 user_id 过滤会 miss
+   Editor 的附件留下孤儿。`gc_orphan_attachments_for_ledger` 用 ledger_id scope。
+
+2. **删 entity 时压缩 upsert 历史** —— 实体彻底下线后,projection 已删,delete
+   event 单独保留就够其它设备 sync;upsert event 保留是纯浪费。`_compact_entity_upsert_events`
+   清掉 upsert,留 delete。
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.database import Base
+from src.models import (
+    AttachmentFile,
+    Ledger,
+    ReadTxProjection,
+    SyncChange,
+    User,
+    UserAccountProjection,
+    UserCategoryProjection,
+    UserTagProjection,
+)
+from src.projection import (
+    gc_orphan_attachments_for_ledger,
+    upsert_tx,
+)
+from src.sync_applier import (
+    _compact_entity_upsert_events,
+    _delete_budget,
+    _delete_tx,
+    _delete_user_account,
+    _delete_user_category,
+    _delete_user_tag,
+)
+
+
+def _make_db():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    return sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+
+def _seed_shared_ledger(db, *, ledger_id="L1", owner_id="owner", editor_id="editor"):
+    """模拟共享账本:owner 拥有 ledger,editor 是另一个 user。"""
+    db.add(User(id=owner_id, email="owner@x.com", password_hash="h"))
+    db.add(User(id=editor_id, email="editor@x.com", password_hash="h"))
+    db.add(
+        Ledger(
+            id=ledger_id,
+            user_id=owner_id,
+            external_id="ext",
+            name="L",
+            currency="CNY",
+        )
+    )
+    db.flush()
+
+
+def _make_attachment(tmp_path: Path, file_id: str, *, ledger_id: str, user_id: str):
+    """attachment_files row + 物理文件,user_id 是上传者。"""
+    storage_path = tmp_path / f"{file_id}.bin"
+    storage_path.write_bytes(b"dummy")
+    return (
+        AttachmentFile(
+            id=file_id,
+            ledger_id=ledger_id,
+            user_id=user_id,
+            sha256=file_id,
+            size_bytes=5,
+            mime_type="image/png",
+            file_name="a.png",
+            storage_path=str(storage_path),
+        ),
+        storage_path,
+    )
+
+
+def _make_sync_change(
+    *,
+    user_id: str,
+    entity_type: str,
+    entity_sync_id: str,
+    action: str,
+    ledger_id: str | None = None,
+    scope: str = "ledger",
+    updated_at: datetime | None = None,
+    payload: dict | None = None,
+) -> SyncChange:
+    return SyncChange(
+        user_id=user_id,
+        ledger_id=ledger_id,
+        scope=scope,
+        entity_type=entity_type,
+        entity_sync_id=entity_sync_id,
+        action=action,
+        payload_json=payload or {},
+        updated_at=updated_at or datetime.now(timezone.utc),
+    )
+
+
+# ============================================================================
+# gc_orphan_attachments_for_ledger
+# ============================================================================
+
+
+def test_ledger_gc_cleans_editor_attachment_orphan(tmp_path):
+    """共享账本:Editor 上传(attachment.user_id=Editor),Owner-scope delete 调
+    ledger-scope GC → Editor 的附件被正确清掉。"""
+    session_factory = _make_db()
+    with session_factory() as db:
+        _seed_shared_ledger(db)
+        att, path = _make_attachment(
+            tmp_path, "f-by-editor", ledger_id="L1", user_id="editor",
+        )
+        db.add(att)
+        db.commit()
+
+        # ledger-scope GC,不传 user_id,只传 ledger_id
+        n = gc_orphan_attachments_for_ledger(
+            db, ledger_id="L1", file_ids={"f-by-editor"},
+        )
+        db.commit()
+
+        assert n == 1, "Editor 上传的附件应该被清掉(老 user-scope GC 会漏)"
+        assert not path.exists()
+        assert db.get(AttachmentFile, "f-by-editor") is None
+
+
+def test_ledger_gc_preserves_if_other_tx_in_ledger_refs(tmp_path):
+    """同 ledger 下还有另一 user 的 tx projection 引用 → 保留。"""
+    session_factory = _make_db()
+    with session_factory() as db:
+        _seed_shared_ledger(db)
+        att, path = _make_attachment(
+            tmp_path, "f-shared", ledger_id="L1", user_id="editor",
+        )
+        db.add(att)
+        # owner-scope projection 行还引用这个附件
+        db.add(
+            ReadTxProjection(
+                ledger_id="L1",
+                sync_id="tx-A",
+                user_id="owner",
+                tx_type="expense",
+                amount=0.0,
+                happened_at=datetime.now(timezone.utc),
+                tx_index=0,
+                source_change_id=1,
+                attachments_json=json.dumps(
+                    [{"fileName": "a.png", "cloudFileId": "f-shared"}]
+                ),
+            )
+        )
+        db.commit()
+
+        n = gc_orphan_attachments_for_ledger(
+            db, ledger_id="L1", file_ids={"f-shared"},
+        )
+        db.commit()
+
+        assert n == 0
+        assert path.exists()
+        assert db.get(AttachmentFile, "f-shared") is not None
+
+
+def test_ledger_gc_does_not_cross_ledger_boundary(tmp_path):
+    """另一个 ledger 的 tx 引用同 fileId → 不影响本 ledger 的 GC。"""
+    session_factory = _make_db()
+    with session_factory() as db:
+        _seed_shared_ledger(db, ledger_id="L1")
+        db.add(
+            Ledger(
+                id="L2", user_id="owner", external_id="ext2",
+                name="L2", currency="CNY",
+            )
+        )
+        att, path = _make_attachment(
+            tmp_path, "f-l1", ledger_id="L1", user_id="editor",
+        )
+        db.add(att)
+        # L2 里有个 tx 偶然引用了同 fileId(理论上不该发生,但 GC 逻辑应该按 ledger 隔离)
+        db.add(
+            ReadTxProjection(
+                ledger_id="L2",
+                sync_id="tx-L2",
+                user_id="owner",
+                tx_type="expense",
+                amount=0.0,
+                happened_at=datetime.now(timezone.utc),
+                tx_index=0,
+                source_change_id=1,
+                attachments_json=json.dumps(
+                    [{"fileName": "a.png", "cloudFileId": "f-l1"}]
+                ),
+            )
+        )
+        db.commit()
+
+        # 在 L1 scope 内 GC:L1 没引用 → 清掉 L1 的 attachment_files 行
+        # (L2 的 tx 引用不属于本 ledger,不阻止 L1 的清理)
+        n = gc_orphan_attachments_for_ledger(
+            db, ledger_id="L1", file_ids={"f-l1"},
+        )
+        db.commit()
+
+        assert n == 1
+        assert db.get(AttachmentFile, "f-l1") is None
+
+
+# ============================================================================
+# _compact_entity_upsert_events
+# ============================================================================
+
+
+def test_compact_removes_upserts_keeps_delete():
+    """entity 删除时,清掉同 entity_sync_id 的 upsert events,保留 delete event。"""
+    session_factory = _make_db()
+    with session_factory() as db:
+        _seed_shared_ledger(db)
+        # 3 个 upsert + 1 个 delete
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="transaction", entity_sync_id="tx-X",
+            action="upsert", ledger_id="L1", scope="ledger",
+        ))
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="transaction", entity_sync_id="tx-X",
+            action="upsert", ledger_id="L1", scope="ledger",
+        ))
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="transaction", entity_sync_id="tx-X",
+            action="upsert", ledger_id="L1", scope="ledger",
+        ))
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="transaction", entity_sync_id="tx-X",
+            action="delete", ledger_id="L1", scope="ledger",
+        ))
+        db.commit()
+
+        n = _compact_entity_upsert_events(
+            db, user_id="owner", entity_type="transaction",
+            entity_sync_id="tx-X",
+        )
+        db.commit()
+
+        assert n == 3, "应该清掉 3 条 upsert"
+        rows = db.scalars(
+            select(SyncChange).where(
+                SyncChange.entity_sync_id == "tx-X",
+            )
+        ).all()
+        assert len(rows) == 1
+        assert rows[0].action == "delete"
+
+
+def test_compact_isolates_other_entities():
+    """只清目标 entity 的 upsert,不影响其它 entity 或其它 user 的 events。"""
+    session_factory = _make_db()
+    with session_factory() as db:
+        _seed_shared_ledger(db)
+        # 目标:tx-X owner
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="transaction", entity_sync_id="tx-X",
+            action="upsert", ledger_id="L1",
+        ))
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="transaction", entity_sync_id="tx-X",
+            action="delete", ledger_id="L1",
+        ))
+        # 另一 tx,不该动
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="transaction", entity_sync_id="tx-Y",
+            action="upsert", ledger_id="L1",
+        ))
+        # 同 sync_id 但不同 entity_type,不该动
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="budget", entity_sync_id="tx-X",
+            action="upsert", ledger_id="L1",
+        ))
+        # 另一 user 但同 sync_id,不该动
+        db.add(_make_sync_change(
+            user_id="editor", entity_type="transaction", entity_sync_id="tx-X",
+            action="upsert", ledger_id="L1",
+        ))
+        db.commit()
+
+        n = _compact_entity_upsert_events(
+            db, user_id="owner", entity_type="transaction",
+            entity_sync_id="tx-X",
+        )
+        db.commit()
+
+        assert n == 1
+        # tx-X owner transaction 只剩 delete(注意:同 sync_id 不同 entity_type
+        # 的 budget tx-X 不在这一查询里,也不该受影响)
+        owner_tx_x = db.scalars(
+            select(SyncChange).where(
+                SyncChange.user_id == "owner",
+                SyncChange.entity_type == "transaction",
+                SyncChange.entity_sync_id == "tx-X",
+            )
+        ).all()
+        assert len(owner_tx_x) == 1
+        assert owner_tx_x[0].action == "delete"
+
+        # 其它都保留
+        assert db.scalar(
+            select(SyncChange).where(SyncChange.entity_sync_id == "tx-Y")
+        ) is not None
+        assert db.scalar(
+            select(SyncChange).where(
+                SyncChange.entity_type == "budget",
+                SyncChange.entity_sync_id == "tx-X",
+            )
+        ) is not None
+        assert db.scalar(
+            select(SyncChange).where(
+                SyncChange.user_id == "editor",
+                SyncChange.entity_sync_id == "tx-X",
+            )
+        ) is not None
+
+
+def test_compact_no_events_returns_zero():
+    """没有匹配 row → 返 0,不报错。"""
+    session_factory = _make_db()
+    with session_factory() as db:
+        _seed_shared_ledger(db)
+        n = _compact_entity_upsert_events(
+            db, user_id="owner", entity_type="transaction",
+            entity_sync_id="never-existed",
+        )
+        db.commit()
+        assert n == 0
+
+
+# ============================================================================
+# 集成:_delete_tx 完整路径
+# ============================================================================
+
+
+def test_delete_tx_cleans_editor_attachment_and_compacts_log(tmp_path):
+    """完整路径:Editor 上传附件 + tx → delete 来自 owner-scope SyncChange:
+    1. tx projection 行被删
+    2. Editor 上传的 attachment_files 行被清(ledger-scope GC)
+    3. 该 tx 的 upsert events 被压缩,只剩 delete event
+    """
+    session_factory = _make_db()
+    with session_factory() as db:
+        _seed_shared_ledger(db)
+        att, path = _make_attachment(
+            tmp_path, "f-by-editor", ledger_id="L1", user_id="editor",
+        )
+        db.add(att)
+        # tx projection 行(共享账本里挂 owner 的 user_id)
+        upsert_tx(
+            db,
+            ledger_id="L1",
+            user_id="owner",
+            source_change_id=10,
+            payload={
+                "syncId": "tx-DEL",
+                "type": "expense",
+                "amount": 10.0,
+                "happenedAt": "2026-05-28T00:00:00Z",
+                "attachments": [
+                    {"fileName": "a.png", "cloudFileId": "f-by-editor"},
+                ],
+            },
+        )
+        # 历史 upsert events(owner-scope log)
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="transaction", entity_sync_id="tx-DEL",
+            action="upsert", ledger_id="L1",
+        ))
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="transaction", entity_sync_id="tx-DEL",
+            action="upsert", ledger_id="L1",
+        ))
+        # delete event
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="transaction", entity_sync_id="tx-DEL",
+            action="delete", ledger_id="L1",
+        ))
+        db.commit()
+
+        # 模拟 sync_applier 调 _delete_tx 时传 owner 的 user_id(ledger_owner_id)
+        _delete_tx(db, ledger_id="L1", sync_id="tx-DEL", user_id="owner")
+        db.commit()
+
+        # 1. tx projection 行已删
+        assert db.scalar(
+            select(ReadTxProjection).where(ReadTxProjection.sync_id == "tx-DEL")
+        ) is None
+
+        # 2. Editor 上传的 attachment 行被清
+        assert db.get(AttachmentFile, "f-by-editor") is None
+        assert not path.exists()
+
+        # 3. sync_changes 里 tx-DEL 只剩 delete event
+        remaining = db.scalars(
+            select(SyncChange).where(SyncChange.entity_sync_id == "tx-DEL")
+        ).all()
+        assert len(remaining) == 1
+        assert remaining[0].action == "delete"
+
+
+# ============================================================================
+# 其它 entity 类型的 compaction
+# ============================================================================
+
+
+def test_delete_user_account_compacts():
+    """删 account 也清掉 upsert 历史。"""
+    session_factory = _make_db()
+    with session_factory() as db:
+        _seed_shared_ledger(db)
+        db.add(
+            UserAccountProjection(
+                user_id="owner", sync_id="acc-X", name="cash",
+                account_type="cash", currency="CNY", initial_balance=0.0,
+                source_change_id=1,
+            )
+        )
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="account", entity_sync_id="acc-X",
+            action="upsert", scope="user",
+        ))
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="account", entity_sync_id="acc-X",
+            action="delete", scope="user",
+        ))
+        db.commit()
+
+        _delete_user_account(db, user_id="owner", sync_id="acc-X")
+        db.commit()
+
+        remaining = db.scalars(
+            select(SyncChange).where(SyncChange.entity_sync_id == "acc-X")
+        ).all()
+        assert len(remaining) == 1
+        assert remaining[0].action == "delete"
+
+
+def test_delete_user_tag_compacts():
+    """删 tag 也清掉 upsert 历史。"""
+    session_factory = _make_db()
+    with session_factory() as db:
+        _seed_shared_ledger(db)
+        db.add(
+            UserTagProjection(
+                user_id="owner", sync_id="tag-X", name="dinner",
+                source_change_id=1,
+            )
+        )
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="tag", entity_sync_id="tag-X",
+            action="upsert", scope="user",
+        ))
+        db.commit()
+
+        _delete_user_tag(db, user_id="owner", sync_id="tag-X")
+        db.commit()
+
+        # 没有 delete event 也照样压缩(虽然语义上有点怪,但实际不会发生 —
+        # 调用方一定是 delete event handler,此时 delete event 是 caller 自己
+        # 拿着的那一条,还没写进 sync_changes 表,要不要写视上下游 router 决定)
+        # 这里测的是 _compact 函数本身的行为:删掉所有 upsert
+        remaining = db.scalars(
+            select(SyncChange).where(SyncChange.entity_sync_id == "tag-X")
+        ).all()
+        assert len(remaining) == 0
+
+
+def test_delete_user_category_compacts():
+    """删 category 同样压缩(category 还有 icon GC 路径要走,确认它没破)。"""
+    session_factory = _make_db()
+    with session_factory() as db:
+        _seed_shared_ledger(db)
+        db.add(
+            UserCategoryProjection(
+                user_id="owner", sync_id="cat-X", name="food",
+                kind="expense", source_change_id=1,
+            )
+        )
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="category", entity_sync_id="cat-X",
+            action="upsert", scope="user",
+        ))
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="category", entity_sync_id="cat-X",
+            action="delete", scope="user",
+        ))
+        db.commit()
+
+        _delete_user_category(db, user_id="owner", sync_id="cat-X")
+        db.commit()
+
+        remaining = db.scalars(
+            select(SyncChange).where(SyncChange.entity_sync_id == "cat-X")
+        ).all()
+        assert len(remaining) == 1
+        assert remaining[0].action == "delete"
+
+
+def test_delete_budget_compacts():
+    """删 budget 也清掉 upsert 历史。"""
+    session_factory = _make_db()
+    with session_factory() as db:
+        _seed_shared_ledger(db)
+        db.add(_make_sync_change(
+            user_id="owner", entity_type="budget", entity_sync_id="bud-X",
+            action="upsert", ledger_id="L1", scope="ledger",
+        ))
+        db.commit()
+
+        _delete_budget(db, ledger_id="L1", sync_id="bud-X", user_id="owner")
+        db.commit()
+
+        remaining = db.scalars(
+            select(SyncChange).where(SyncChange.entity_sync_id == "bud-X")
+        ).all()
+        assert len(remaining) == 0


### PR DESCRIPTION
## 背景

dev 环境实测共享账本 Editor 在 Owner 分享的账本里删一笔带附件的 tx,server 端 attachment_files 表行留作孤儿(物理文件也没 unlink)。诊断后发现两个独立但相关的问题:

### 问题 1:GC 用 user_id scope,共享账本场景下 user_id 错配

\`\`\`
attachment_files.user_id  = Editor (上传者)
SyncChange.user_id        = Owner  (账本所有者,event log 挂这里)
\`\`\`

\`_delete_tx\` 调 \`gc_orphan_attachments(user_id=ledger_owner_id)\` 按 Owner 过滤 attachment_files → 找不到 Editor 的附件 → 静默跳过 → 孤儿留下。

### 问题 2:entity 删除后,upsert 历史 events 永远留着浪费空间

sync_changes 是 append-only event log,entity 被删后所有 upsert events 失去意义但仍占空间。10 笔被删的 tx 平均每笔 3 次 edit → 30 条废弃 upsert events。

## 修复

### 1) \`projection.py\`:加 ledger-scope GC

- 新增 \`gc_orphan_attachments_for_ledger(ledger_id, file_ids)\` —— 按 ledger_id 过滤(不按 user_id)
- 新增 \`_fileid_still_referenced_in_ledger\` —— 引用检查也按 ledger_id 扫所有 user 的 projection
- 原 \`gc_orphan_attachments(user_id, ...)\` 保留给 category icon 等 user-scope 实体

### 2) \`sync_applier.py\`:\`_delete_tx\` 切换到 ledger-scope GC

共享账本场景:Editor / Owner 谁删 tx 都能正确清理对方上传的附件。

### 3) \`sync_applier.py\`:新增 \`_compact_entity_upsert_events\` helper

entity delete 时清掉同 \`(user_id, entity_type, entity_sync_id)\` 的所有 upsert events,**保留 delete event**。tx / budget / account / category / tag 五个 delete handler 全部连带压缩。

**为什么安全**:
- apply 路径对 delete event 是 idempotent no-op(\`if existingId==null return\`),晚到的设备只看 delete event 也能正确同步
- projection 跟 log 同时下线 entity,不会出现 21136 那种 dangling \`source_change_id\` 问题
- delete event 本身保留,确保 cursor 落后的设备能 apply

## 测试

\`tests/test_shared_ledger_delete_cleanup.py\` 11 个新 test 锁定:
- ledger-scope GC 正确清 Editor 上传的附件
- ledger-scope GC 不跨 ledger 边界
- \`_compact\` 只清目标 entity
- 5 个 entity delete 路径都正确压缩
- 集成测试:\`_delete_tx\` 完整路径

\`pytest tests/\` 292 个 test 全过。