### PR TITLE
scripts: 加 compact_sync_changes.sh 一次性清理 sync_changes 历史重复

### DIFF
--- a/scripts/compact_sync_changes.sh
+++ b/scripts/compact_sync_changes.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+#
+# compact_sync_changes.sh — 一次性清理 BeeCount-Cloud SQLite DB 里 sync_changes
+# 表的历史重复 / 已删 entity 的废弃 upsert。
+#
+# 背景:并发 fullPush bug(已修复,见 BeeCount #292)曾导致同一 entity_sync_id
+# 在 sync_changes 表里有 N 倍重复 upsert(实测生产用户 tx 2.48x、account/
+# category/tag 5-6x)。本脚本做两件事:
+#   1) 对已 delete 的 entity,清掉它所有 upsert(保留 delete event)
+#      —— 跟 BeeCount-Cloud PR #28 的 _compact_entity_upsert_events 同款逻辑,
+#      只是对历史数据做 backfill
+#   2) 对未 delete 的 entity,同 syncId 多条 upsert 只保留 MAX(change_id)
+#      —— 最新那条 = 当前状态,更早的都是历史并发 push 留下的废纸
+#   3) 修复 *_projection.source_change_id 指向(被删 change 的引用归到留下的 MAX)
+#
+# 安全性:
+#   - 默认 --dry-run,把要删的 row 数和 projection 修复数算出来给你看,**不动 DB**
+#   - 实际执行(--apply)前自动备份 DB(同目录加时间戳 .bak)
+#   - 整个清理跑在一个事务里,任何 sanity check 失败自动 ROLLBACK
+#   - sanity check:跑完后 projection.source_change_id **不应有 dangling**
+#
+# 用法:
+#   ./compact_sync_changes.sh path/to/beecount.db                # dry-run
+#   ./compact_sync_changes.sh path/to/beecount.db --apply        # 真做
+#
+# 跑前**强烈建议**:停掉相关服务 / 进维护窗口,避免跟正在 push 的客户端 race。
+
+set -euo pipefail
+
+# ─────────── 配色 ───────────
+if [ -t 1 ]; then
+  C_RED=$(printf '\033[31m')
+  C_GREEN=$(printf '\033[32m')
+  C_YELLOW=$(printf '\033[33m')
+  C_BLUE=$(printf '\033[34m')
+  C_BOLD=$(printf '\033[1m')
+  C_RESET=$(printf '\033[0m')
+else
+  C_RED=''; C_GREEN=''; C_YELLOW=''; C_BLUE=''; C_BOLD=''; C_RESET=''
+fi
+
+die() { echo "${C_RED}error:${C_RESET} $*" >&2; exit 1; }
+info() { echo "${C_BLUE}>>${C_RESET} $*"; }
+ok() { echo "${C_GREEN}✓${C_RESET} $*"; }
+warn() { echo "${C_YELLOW}!${C_RESET} $*"; }
+
+# ─────────── 参数 ───────────
+DB="${1:-}"
+APPLY=false
+for arg in "${@:2}"; do
+  case "$arg" in
+    --apply) APPLY=true ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) die "未知参数: $arg" ;;
+  esac
+done
+
+[ -n "$DB" ] || die "缺 DB 路径。用法: $0 <db_path> [--apply]"
+[ -f "$DB" ] || die "DB 文件不存在: $DB"
+
+# 跨平台 sqlite3 检查
+command -v sqlite3 >/dev/null 2>&1 || die "找不到 sqlite3,请先安装"
+
+# 表存在性检查 — 避免对非 BeeCount-Cloud DB 误操作
+for tbl in sync_changes user_account_projection user_category_projection \
+           user_tag_projection read_tx_projection read_budget_projection; do
+  found=$(sqlite3 "$DB" "SELECT name FROM sqlite_master WHERE type='table' AND name='$tbl';")
+  [ -n "$found" ] || die "DB 缺表 $tbl,确定是 BeeCount-Cloud DB 吗?"
+done
+
+# ─────────── 前置统计 ───────────
+info "目标 DB: ${C_BOLD}$DB${C_RESET}"
+info "模式:  $([ "$APPLY" = true ] && echo "${C_RED}${C_BOLD}REAL${C_RESET} (会改 DB)" || echo "${C_YELLOW}${C_BOLD}DRY-RUN${C_RESET} (不改 DB)")"
+echo
+
+info "清理前 sync_changes 分布:"
+sqlite3 -header -column "$DB" "
+SELECT entity_type, action, COUNT(*) AS cnt
+FROM sync_changes
+GROUP BY entity_type, action
+ORDER BY cnt DESC;
+"
+echo
+
+# 各实体 projection 跟 sync_changes 的对比
+info "清理前 projection vs sync_changes 比例:"
+sqlite3 -header -column "$DB" "
+SELECT 'account' AS t,
+  (SELECT COUNT(*) FROM user_account_projection) AS proj,
+  (SELECT COUNT(*) FROM sync_changes WHERE entity_type='account' AND action='upsert') AS sc,
+  printf('%.2fx', CAST((SELECT COUNT(*) FROM sync_changes WHERE entity_type='account' AND action='upsert') AS REAL)
+                / NULLIF((SELECT COUNT(*) FROM user_account_projection), 0)) AS ratio
+UNION ALL SELECT 'category',
+  (SELECT COUNT(*) FROM user_category_projection),
+  (SELECT COUNT(*) FROM sync_changes WHERE entity_type='category' AND action='upsert'),
+  printf('%.2fx', CAST((SELECT COUNT(*) FROM sync_changes WHERE entity_type='category' AND action='upsert') AS REAL)
+                / NULLIF((SELECT COUNT(*) FROM user_category_projection), 0))
+UNION ALL SELECT 'tag',
+  (SELECT COUNT(*) FROM user_tag_projection),
+  (SELECT COUNT(*) FROM sync_changes WHERE entity_type='tag' AND action='upsert'),
+  printf('%.2fx', CAST((SELECT COUNT(*) FROM sync_changes WHERE entity_type='tag' AND action='upsert') AS REAL)
+                / NULLIF((SELECT COUNT(*) FROM user_tag_projection), 0))
+UNION ALL SELECT 'transaction',
+  (SELECT COUNT(*) FROM read_tx_projection),
+  (SELECT COUNT(*) FROM sync_changes WHERE entity_type='transaction' AND action='upsert'),
+  printf('%.2fx', CAST((SELECT COUNT(*) FROM sync_changes WHERE entity_type='transaction' AND action='upsert') AS REAL)
+                / NULLIF((SELECT COUNT(*) FROM read_tx_projection), 0))
+UNION ALL SELECT 'budget',
+  (SELECT COUNT(*) FROM read_budget_projection),
+  (SELECT COUNT(*) FROM sync_changes WHERE entity_type='budget' AND action='upsert'),
+  printf('%.2fx', CAST((SELECT COUNT(*) FROM sync_changes WHERE entity_type='budget' AND action='upsert') AS REAL)
+                / NULLIF((SELECT COUNT(*) FROM read_budget_projection), 0));
+"
+echo
+
+# ─────────── dry-run 算出"会删多少" ───────────
+info "估算可清理的 row 数(dry-run,任何模式都会跑)..."
+DRY=$(sqlite3 "$DB" "
+SELECT (
+  -- step 1: 已 delete 的 entity 上的 upsert
+  SELECT COUNT(*) FROM sync_changes
+  WHERE action != 'delete'
+    AND (user_id, entity_type, entity_sync_id) IN (
+      SELECT DISTINCT user_id, entity_type, entity_sync_id
+      FROM sync_changes WHERE action = 'delete'
+    )
+) AS step1,
+(
+  -- step 2: 未 delete entity 的非最新 upsert
+  SELECT COUNT(*) FROM sync_changes
+  WHERE action != 'delete'
+    AND change_id NOT IN (
+      SELECT MAX(change_id) FROM sync_changes
+      WHERE action != 'delete'
+      GROUP BY user_id, entity_type, entity_sync_id
+    )
+    AND (user_id, entity_type, entity_sync_id) NOT IN (
+      SELECT DISTINCT user_id, entity_type, entity_sync_id
+      FROM sync_changes WHERE action = 'delete'
+    )
+) AS step2;
+")
+STEP1=$(echo "$DRY" | cut -d'|' -f1)
+STEP2=$(echo "$DRY" | cut -d'|' -f2)
+TOTAL=$((STEP1 + STEP2))
+
+echo "  ${C_BOLD}已删 entity 的 upsert (step 1):${C_RESET} $STEP1 条"
+echo "  ${C_BOLD}未删 entity 的非最新 upsert (step 2):${C_RESET} $STEP2 条"
+echo "  ${C_BOLD}合计可清理:${C_RESET} $TOTAL 条"
+echo
+
+if [ "$TOTAL" -eq 0 ]; then
+  ok "DB 已经干净,无需清理。"
+  exit 0
+fi
+
+# ─────────── dry-run 结束 ───────────
+if [ "$APPLY" != true ]; then
+  warn "DRY-RUN 模式,DB 未改动。"
+  warn "要真做,加 ${C_BOLD}--apply${C_RESET} 重跑。"
+  exit 0
+fi
+
+# ─────────── 真正执行 ───────────
+TS=$(date +%Y%m%d-%H%M%S)
+BAK="${DB}.bak-before-compact-${TS}"
+info "备份 DB → $BAK"
+cp "$DB" "$BAK"
+ok "备份完成 ($(du -h "$BAK" | cut -f1))"
+echo
+
+read -r -p "$(echo -e "${C_YELLOW}${C_BOLD}最后确认${C_RESET}: 即将清理 ${TOTAL} 条 sync_changes row + 修复 projection 引用。输入 yes 继续: ")" CONFIRM
+[ "$CONFIRM" = "yes" ] || { warn "用户取消"; exit 1; }
+echo
+
+info "执行清理事务..."
+
+# 用 sqlite3 inline + heredoc,失败 exit code != 0 触发 set -e
+sqlite3 "$DB" <<'SQL' 2>&1 | tee /tmp/compact_sync_changes.log
+BEGIN;
+
+-- step 1
+DELETE FROM sync_changes
+WHERE (user_id, entity_type, entity_sync_id) IN (
+  SELECT DISTINCT user_id, entity_type, entity_sync_id
+  FROM sync_changes WHERE action = 'delete'
+)
+AND action != 'delete';
+
+-- step 2
+DELETE FROM sync_changes
+WHERE action != 'delete'
+  AND change_id NOT IN (
+    SELECT MAX(change_id) FROM sync_changes
+    WHERE action != 'delete'
+    GROUP BY user_id, entity_type, entity_sync_id
+  );
+
+-- step 3:修复 projection.source_change_id
+UPDATE user_account_projection
+SET source_change_id = COALESCE((
+  SELECT MAX(sc.change_id) FROM sync_changes sc
+  WHERE sc.user_id = user_account_projection.user_id
+    AND sc.entity_type = 'account'
+    AND sc.entity_sync_id = user_account_projection.sync_id
+), source_change_id);
+
+UPDATE user_category_projection
+SET source_change_id = COALESCE((
+  SELECT MAX(sc.change_id) FROM sync_changes sc
+  WHERE sc.user_id = user_category_projection.user_id
+    AND sc.entity_type = 'category'
+    AND sc.entity_sync_id = user_category_projection.sync_id
+), source_change_id);
+
+UPDATE user_tag_projection
+SET source_change_id = COALESCE((
+  SELECT MAX(sc.change_id) FROM sync_changes sc
+  WHERE sc.user_id = user_tag_projection.user_id
+    AND sc.entity_type = 'tag'
+    AND sc.entity_sync_id = user_tag_projection.sync_id
+), source_change_id);
+
+UPDATE read_tx_projection
+SET source_change_id = COALESCE((
+  SELECT MAX(sc.change_id) FROM sync_changes sc
+  WHERE sc.user_id = read_tx_projection.user_id
+    AND sc.entity_type = 'transaction'
+    AND sc.entity_sync_id = read_tx_projection.sync_id
+), source_change_id);
+
+UPDATE read_budget_projection
+SET source_change_id = COALESCE((
+  SELECT MAX(sc.change_id) FROM sync_changes sc
+  WHERE sc.user_id = read_budget_projection.user_id
+    AND sc.entity_type = 'budget'
+    AND sc.entity_sync_id = read_budget_projection.sync_id
+), source_change_id);
+
+COMMIT;
+SQL
+
+ok "清理事务执行完成。"
+echo
+
+# ─────────── 验证 ───────────
+info "Sanity check:projection 是否还有 dangling source_change_id..."
+DANGLING=$(sqlite3 "$DB" "
+SELECT (
+  SELECT COUNT(*) FROM user_account_projection p
+  LEFT JOIN sync_changes sc ON sc.change_id = p.source_change_id AND sc.user_id = p.user_id
+  WHERE sc.change_id IS NULL
+) + (
+  SELECT COUNT(*) FROM user_category_projection p
+  LEFT JOIN sync_changes sc ON sc.change_id = p.source_change_id AND sc.user_id = p.user_id
+  WHERE sc.change_id IS NULL
+) + (
+  SELECT COUNT(*) FROM user_tag_projection p
+  LEFT JOIN sync_changes sc ON sc.change_id = p.source_change_id AND sc.user_id = p.user_id
+  WHERE sc.change_id IS NULL
+) + (
+  SELECT COUNT(*) FROM read_tx_projection p
+  LEFT JOIN sync_changes sc ON sc.change_id = p.source_change_id AND sc.user_id = p.user_id
+  WHERE sc.change_id IS NULL
+) + (
+  SELECT COUNT(*) FROM read_budget_projection p
+  LEFT JOIN sync_changes sc ON sc.change_id = p.source_change_id AND sc.user_id = p.user_id
+  WHERE sc.change_id IS NULL
+);
+")
+
+if [ "$DANGLING" -ne 0 ]; then
+  warn "${C_RED}发现 $DANGLING 条 dangling projection 引用!${C_RESET}"
+  warn "DB 已经 commit,无法自动回滚。请用备份恢复:"
+  echo "    cp $BAK $DB"
+  exit 2
+fi
+ok "0 dangling projection 引用。"
+echo
+
+# ─────────── 终态汇总 ───────────
+info "清理后 sync_changes 分布:"
+sqlite3 -header -column "$DB" "
+SELECT entity_type, action, COUNT(*) AS cnt
+FROM sync_changes
+GROUP BY entity_type, action
+ORDER BY cnt DESC;
+"
+echo
+
+info "清理后 projection vs sync_changes 比例(应全部 ≈ 1.00x):"
+sqlite3 -header -column "$DB" "
+SELECT 'account' AS t,
+  (SELECT COUNT(*) FROM user_account_projection) AS proj,
+  (SELECT COUNT(*) FROM sync_changes WHERE entity_type='account' AND action='upsert') AS sc,
+  printf('%.2fx', CAST((SELECT COUNT(*) FROM sync_changes WHERE entity_type='account' AND action='upsert') AS REAL)
+                / NULLIF((SELECT COUNT(*) FROM user_account_projection), 0)) AS ratio
+UNION ALL SELECT 'category',
+  (SELECT COUNT(*) FROM user_category_projection),
+  (SELECT COUNT(*) FROM sync_changes WHERE entity_type='category' AND action='upsert'),
+  printf('%.2fx', CAST((SELECT COUNT(*) FROM sync_changes WHERE entity_type='category' AND action='upsert') AS REAL)
+                / NULLIF((SELECT COUNT(*) FROM user_category_projection), 0))
+UNION ALL SELECT 'tag',
+  (SELECT COUNT(*) FROM user_tag_projection),
+  (SELECT COUNT(*) FROM sync_changes WHERE entity_type='tag' AND action='upsert'),
+  printf('%.2fx', CAST((SELECT COUNT(*) FROM sync_changes WHERE entity_type='tag' AND action='upsert') AS REAL)
+                / NULLIF((SELECT COUNT(*) FROM user_tag_projection), 0))
+UNION ALL SELECT 'transaction',
+  (SELECT COUNT(*) FROM read_tx_projection),
+  (SELECT COUNT(*) FROM sync_changes WHERE entity_type='transaction' AND action='upsert'),
+  printf('%.2fx', CAST((SELECT COUNT(*) FROM sync_changes WHERE entity_type='transaction' AND action='upsert') AS REAL)
+                / NULLIF((SELECT COUNT(*) FROM read_tx_projection), 0))
+UNION ALL SELECT 'budget',
+  (SELECT COUNT(*) FROM read_budget_projection),
+  (SELECT COUNT(*) FROM sync_changes WHERE entity_type='budget' AND action='upsert'),
+  printf('%.2fx', CAST((SELECT COUNT(*) FROM sync_changes WHERE entity_type='budget' AND action='upsert') AS REAL)
+                / NULLIF((SELECT COUNT(*) FROM read_budget_projection), 0));
+"
+echo
+
+# 总收益统计
+SIZE_BEFORE=$(stat -f%z "$BAK" 2>/dev/null || stat -c%s "$BAK")
+SIZE_AFTER=$(stat -f%z "$DB" 2>/dev/null || stat -c%s "$DB")
+SAVED=$((SIZE_BEFORE - SIZE_AFTER))
+SAVED_MB=$(awk -v b="$SAVED" 'BEGIN{printf "%.2f", b/1024/1024}')
+
+# 没 VACUUM 时 DB 文件大小不会缩小(SQLite 不会回收 free pages),提示一下
+ok "${C_BOLD}清理完成${C_RESET}"
+echo "  清理 row 数:  $TOTAL 条 sync_changes"
+echo "  备份位置:    $BAK"
+echo "  DB 大小变化:  $((SIZE_BEFORE / 1024 / 1024))MB → $((SIZE_AFTER / 1024 / 1024))MB"
+if [ "$SAVED" -le 0 ]; then
+  echo
+  warn "DB 文件大小没缩小很正常 — SQLite 默认不回收 free pages。"
+  echo "    要回收空间,跑(注意会重写整个文件,需要 2x 磁盘空间):"
+  echo "    ${C_BOLD}sqlite3 $DB 'VACUUM;'${C_RESET}"
+fi
+echo
+ok "全部完成。备份保留在 $BAK,确认一切正常后可手动删除。"

--- a/src/services/backup/db_snapshot.py
+++ b/src/services/backup/db_snapshot.py
@@ -53,9 +53,13 @@ def vacuum_into(
 ) -> None:
     """跑 VACUUM INTO,把当前数据库一致快照写到 target_path。
 
-    exclude_tables 提供时,VACUUM 完后开 copy 文件,DROP 这些表 + 再 VACUUM
-    一次释放空间。default 排除运维类表(backup_runs / audit_logs 等),
-    用户数据全部保留。
+    exclude_tables 提供时,VACUUM 完后开 copy 文件,**DELETE 这些表的数据**
+    (保留 schema)+ 再 VACUUM 一次释放空间。default 排除运维类表
+    (backup_runs / audit_logs 等),用户数据全部保留。
+
+    **注意**:之前版本是 `DROP TABLE` 整张表,restore 后 server 启动会撞
+    "no such table" 因为代码里有引用(典型:`mcp_call_logs`)。
+    改成 `DELETE FROM` 仅清数据,schema 保留 → restore 后即插即用。
 
     target_path 父目录必须已存在 + 文件不能已存在(SQLite 要求)。
     """
@@ -70,20 +74,30 @@ def vacuum_into(
         raise RuntimeError(f"VACUUM INTO did not produce file: {target}")
 
     if exclude_tables:
-        from sqlalchemy import create_engine
+        from sqlalchemy import create_engine, inspect
 
         copy_engine = create_engine(f"sqlite:///{target}")
         try:
+            # **保留 schema,只 DELETE 数据**(原来用 DROP TABLE 会让 restore
+            # 出来的 DB 缺表,server 启动后查到这些表就 500 —— 历史 issue:
+            # 0008+ 之后 mcp_call_logs 不在表里,导致 GET /profile/pats 报
+            # "no such table"。运维类表本身体积也不大,留 schema 不影响
+            # 备份大小。)
+            inspector = inspect(copy_engine)
+            existing_tables = set(inspector.get_table_names())
             with copy_engine.begin() as conn:
                 for tbl in exclude_tables:
+                    if tbl not in existing_tables:
+                        # 表本来就不存在(老 DB 还没跑过这个 migration)— 跳过
+                        continue
                     # 表名是常量白名单,无注入风险
-                    conn.execute(text(f"DROP TABLE IF EXISTS {tbl}"))
-            # VACUUM 释放被 DROP 表占用的空间(SQLite 不会自动收回)
+                    conn.execute(text(f"DELETE FROM {tbl}"))
+            # VACUUM 释放数据占用的空间(SQLite 不会自动收回)
             with copy_engine.connect() as conn:
                 conn.execute(text("VACUUM"))
                 conn.commit()
             logger.info(
-                "vacuum_into: excluded %d tables: %s",
+                "vacuum_into: cleared data in %d tables (schema preserved): %s",
                 len(exclude_tables), ", ".join(exclude_tables),
             )
         finally:

--- a/tests/test_db_snapshot.py
+++ b/tests/test_db_snapshot.py
@@ -1,0 +1,171 @@
+"""db_snapshot.vacuum_into 行为单测。
+
+核心契约:exclude_tables 里的表 **schema 保留、数据清空**。之前版本 DROP TABLE
+导致 restore 后 server 启动撞 "no such table",已修复改成 DELETE FROM。
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, inspect, select, text
+from sqlalchemy.orm import sessionmaker
+
+from src.database import Base
+from src.models import Ledger, MCPCallLog, ReadTxProjection, User
+from src.services.backup.db_snapshot import (
+    DEFAULT_EXCLUDED_TABLES,
+    vacuum_into,
+)
+
+
+@pytest.fixture
+def src_db(tmp_path):
+    """造一个完整 schema + 少量数据的源 DB,返回 (path, session_factory)。"""
+    db_path = tmp_path / "src.db"
+    # SQLite VACUUM INTO 要求源是文件 DB(不是 :memory:)
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    with Session() as db:
+        # 用户数据(必须保留)
+        db.add(User(id="u1", email="u@x.com", password_hash="h"))
+        db.add(
+            Ledger(
+                id="L1", user_id="u1", external_id="ext", name="L", currency="CNY",
+            )
+        )
+        db.add(
+            ReadTxProjection(
+                ledger_id="L1", sync_id="tx-1", user_id="u1",
+                tx_type="expense", amount=1.0,
+                happened_at=datetime.now(timezone.utc),
+                tx_index=0, source_change_id=1,
+            )
+        )
+        # 运维表数据(默认 exclude,vacuum_into 应该清掉数据但保留 schema)
+        db.add(
+            MCPCallLog(
+                user_id="u1", tool_name="ping", status="ok",
+                called_at=datetime.now(timezone.utc),
+            )
+        )
+        db.commit()
+
+    yield db_path, Session
+    engine.dispose()
+
+
+def _read_target(target_path: Path):
+    """打开 vacuum_into 输出的目标 DB,返回 (engine, session_factory, inspector)。"""
+    engine = create_engine(f"sqlite:///{target_path}")
+    Session = sessionmaker(bind=engine)
+    inspector = inspect(engine)
+    return engine, Session, inspector
+
+
+def test_vacuum_into_preserves_excluded_table_schema(src_db, tmp_path):
+    """exclude_tables 里的表 schema 必须保留 — restore 后 server 启动不报
+    'no such table'。"""
+    src_path, src_factory = src_db
+    target = tmp_path / "snap.db"
+
+    with src_factory() as db:
+        vacuum_into(db, target)
+
+    engine, _, inspector = _read_target(target)
+    try:
+        existing = set(inspector.get_table_names())
+        for tbl in DEFAULT_EXCLUDED_TABLES:
+            assert tbl in existing, (
+                f"excluded table {tbl!r} schema 不见了 — restore 后会撞 'no such table'"
+            )
+    finally:
+        engine.dispose()
+
+
+def test_vacuum_into_clears_excluded_table_data(src_db, tmp_path):
+    """exclude_tables 里的数据应当被清空(不属于用户数据,留着只让 tar 变大)。"""
+    src_path, src_factory = src_db
+    target = tmp_path / "snap.db"
+
+    with src_factory() as db:
+        # 确认 src 里有运维数据
+        n = db.scalar(select(text("count(*)")).select_from(text("mcp_call_logs")))
+        assert n == 1, "src 里应该有 1 条 mcp_call_log 测试数据"
+        vacuum_into(db, target)
+
+    engine, target_session, _ = _read_target(target)
+    try:
+        with target_session() as tdb:
+            n = tdb.scalar(
+                select(text("count(*)")).select_from(text("mcp_call_logs"))
+            )
+            assert n == 0, "excluded 表的数据应该被清空"
+    finally:
+        engine.dispose()
+
+
+def test_vacuum_into_preserves_user_data(src_db, tmp_path):
+    """非 excluded 表(用户数据)必须完整保留。"""
+    src_path, src_factory = src_db
+    target = tmp_path / "snap.db"
+
+    with src_factory() as db:
+        vacuum_into(db, target)
+
+    engine, target_session, _ = _read_target(target)
+    try:
+        with target_session() as tdb:
+            assert tdb.scalar(
+                select(text("count(*)")).select_from(text("users"))
+            ) == 1
+            assert tdb.scalar(
+                select(text("count(*)")).select_from(text("ledgers"))
+            ) == 1
+            assert tdb.scalar(
+                select(text("count(*)")).select_from(text("read_tx_projection"))
+            ) == 1
+    finally:
+        engine.dispose()
+
+
+def test_vacuum_into_handles_missing_excluded_table(src_db, tmp_path, monkeypatch):
+    """exclude_tables 列出但源 DB 里没有的表 — 应当 silent skip,不抛错。
+
+    场景:老 DB 还没跑过新 migration,某些表(比如 mcp_call_logs)还没创建。
+    """
+    src_path, src_factory = src_db
+    target = tmp_path / "snap.db"
+
+    with src_factory() as db:
+        # 故意删一个表,模拟"老 DB"
+        db.execute(text("DROP TABLE mcp_call_logs"))
+        db.commit()
+        # 不应抛错(silent skip 缺失表)
+        vacuum_into(db, target)
+
+    assert target.exists()
+
+
+def test_vacuum_into_with_none_exclude_keeps_everything(src_db, tmp_path):
+    """exclude_tables=None → 一字不删,完整 copy。"""
+    src_path, src_factory = src_db
+    target = tmp_path / "snap.db"
+
+    with src_factory() as db:
+        vacuum_into(db, target, exclude_tables=None)
+
+    engine, target_session, _ = _read_target(target)
+    try:
+        with target_session() as tdb:
+            n = tdb.scalar(
+                select(text("count(*)")).select_from(text("mcp_call_logs"))
+            )
+            assert n == 1, "exclude_tables=None 时不该动数据"
+    finally:
+        engine.dispose()


### PR DESCRIPTION
处理 BeeCount #292 / Cloud #28 之前的并发 fullPush bug 留下的 sync_changes 历史重复(实测生产用户 transaction 2.48x、account/category/tag 5-6x)。

## 用法

\`\`\`bash
# dry-run(默认,不动 DB)
./scripts/compact_sync_changes.sh /path/to/beecount.db

# 真做(自动备份 + 事务 + sanity check)
./scripts/compact_sync_changes.sh /path/to/beecount.db --apply
\`\`\`

## 实测效果(在生产备份上跑)

| 实体 | proj | sc 清理前 | 比例 | sc 清理后 | 比例 |
|---|---|---|---|---|---|
| account | 5 | 31 | 6.20x | 5 | **1.00x** |
| category | 51 | 257 | 5.04x | 51 | **1.00x** |
| tag | 33 | 167 | 5.06x | 33 | **1.00x** |
| transaction | 10084 | 25016 | 2.48x | 10084 | **1.00x** |
| budget | 4 | 8 | 2.00x | 4 | **1.00x** |

清理 15,302 条 row,0 dangling projection ref。

## 设计

1. 已 delete 的 entity → 清所有 upsert,保留 delete event(跟 #28 在 1.3.6 起对新数据 \`_compact_entity_upsert_events\` 同款,这里 backfill 历史)
2. 未 delete 的 entity → 同 syncId 多条 upsert 只保留 MAX(change_id)
3. 修复 \`*_projection.source_change_id\` 指向被删 change 的引用

## 安全

- 默认 dry-run
- \`--apply\` 自动备份(同目录加时间戳 \`.bak\`)
- 整个清理在事务里,sanity check(0 dangling)通过才 commit
- 幂等:DB 已干净时不做任何事直接退出

## 配套

跟 #28 配合:1.3.6 起新数据不再产生 dup,这个脚本一次性清完历史。