### PR TITLE
fix(server): MCP 写入幽灵账本 + 批量写性能 (#31)

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -6,10 +6,10 @@
 
 ## 是什么
 
-MCP 是 Anthropic 推出的 LLM-工具集成协议。BeeCount Cloud 内置一个 MCP server,把账本能力暴露成 17 个 tool:
+MCP 是 Anthropic 推出的 LLM-工具集成协议。BeeCount Cloud 内置一个 MCP server,把账本能力暴露成 18 个 tool:
 
 - **11 个 read tool**:`list_ledgers` / `list_transactions` / `list_categories` / `list_accounts` / `list_tags` / `list_budgets` / `get_ledger_stats` / `get_analytics_summary` / `search` / `get_transaction` / `get_active_ledger`
-- **6 个 write tool**:`create_transaction` / `update_transaction` / `delete_transaction`(需二次确认)/ `create_category` / `update_budget` / `parse_and_create_from_text`(让 BeeCount AI 解析自然语言)
+- **7 个 write tool**:`create_transaction` / `create_transactions`(批量导入,一次提交多笔)/ `update_transaction` / `delete_transaction`(需二次确认)/ `create_category` / `update_budget` / `parse_and_create_from_text`(让 BeeCount AI 解析自然语言)
 
 跟 LLM 聊天时可以这样说:
 
@@ -179,6 +179,7 @@ PAT 跟 access token 严格分流:**PAT 只能用在 `/api/v1/mcp/*`**,所有其
 | Tool | 用途 | 关键参数 |
 |---|---|---|
 | `create_transaction` | 新建交易 | amount, tx_type, category, account, happened_at, note, tags |
+| `create_transactions` | **批量**新建交易(导入正解,一次提交多笔) | transactions(list), ledger_id |
 | `update_transaction` | 改交易 | sync_id + 待改字段 |
 | `delete_transaction` | 删交易(**二次确认**) | sync_id, confirm |
 | `create_category` | 新建分类 | name, kind, parent_name |

--- a/src/mcp/server.py
+++ b/src/mcp/server.py
@@ -1,4 +1,4 @@
-"""BeeCount Cloud MCP server — 注册所有 17 个 tool,导出 ASGI app。
+"""BeeCount Cloud MCP server — 注册所有 18 个 tool,导出 ASGI app。
 
 设计:.docs/mcp-server-design.md。
 
@@ -330,7 +330,7 @@ async def search(ctx: Context, q: str, limit: int = 20) -> list[dict[str, Any]]:
 
 
 # ============================================================================
-# Write tools — 6 个,mcp:write scope
+# Write tools — 7 个,mcp:write scope
 # ============================================================================
 
 
@@ -365,6 +365,34 @@ async def create_transaction(
     return await _logged_call(
         ctx, name="create_transaction", scope=SCOPE_MCP_WRITE, kwargs=kw,
         body=lambda user: write_tools.create_transaction(user, **kw),
+    )
+
+
+@mcp.tool()
+async def create_transactions(
+    ctx: Context,
+    transactions: list[dict[str, Any]],
+    ledger_id: str | None = None,
+) -> dict[str, Any]:
+    """Create many transactions at once — use this for bulk imports.
+
+    Far more efficient than calling create_transaction in a loop: routes through
+    the server's batch endpoint (one commit + one notification per ~50 rows),
+    avoiding the per-row overhead that makes large imports slow/unreliable.
+
+    Args:
+        transactions: list of objects, each like create_transaction's args —
+            {amount (>0), tx_type (expense|income|transfer, default expense),
+             category, account, happened_at (ISO, default now), note, tags}.
+            category/account must be existing names (server rejects unknown ones).
+        ledger_id: Optional. If omitted and you have multiple ledgers, the tool
+            refuses to guess and returns the candidate list — re-call with an id.
+            Max 200 transactions per call; split larger imports across calls.
+    """
+    kw = dict(transactions=transactions, ledger_id=ledger_id)
+    return await _logged_call(
+        ctx, name="create_transactions", scope=SCOPE_MCP_WRITE, kwargs=kw,
+        body=lambda user: write_tools.create_transactions(user, **kw),
     )
 
 

--- a/src/mcp/tools/read_tools.py
+++ b/src/mcp/tools/read_tools.py
@@ -28,18 +28,36 @@ from ...models import (
     UserCategoryProjection,
     UserTagProjection,
 )
+# 复用 read 端的唯一权威"软删除"判定 —— 保证 MCP 与 web/mobile 账本可见性口径
+# 一致(issue #31)。read._shared 不依赖 mcp,无循环 import。
+from ...routers.read._shared import _is_ledger_deleted
 
 
 # ---------- helpers ----------------------------------------------------------
 
 
+def live_ledgers(db: Session, user_id: str) -> list[Ledger]:
+    """该用户所有**未软删**账本,按 created_at 升序。
+
+    issue #31:MCP 历史上直接查 Ledger 表、不过滤软删账本,导致解析 / 列举到
+    web 与 mobile 都看不见的"幽灵账本"(尤其多设备各自上传的默认账本)。这里
+    统一复用 read 端的 `_is_ledger_deleted` 权威判定,跟账本列表口径对齐。
+    """
+    rows = db.scalars(
+        select(Ledger)
+        .where(Ledger.user_id == user_id)
+        .order_by(Ledger.created_at.asc())
+    ).all()
+    return [led for led in rows if not _is_ledger_deleted(db, ledger_id=led.id)]
+
+
 def _resolve_ledger(
     db: Session, user_id: str, ledger_id: str | None
 ) -> Ledger | None:
-    """LLM 友好的 ledger 解析:
-      - ledger_id 是 external_id(用户视角的 id,如 "1" / UUID)→ 按 external_id 查
-      - 空 → 拿用户的第一个账本(active fallback)
-      - 不存在 → None
+    """LLM 友好的 ledger 解析(已排除软删账本,issue #31):
+      - ledger_id 是 external_id(用户视角的 id,如 "1" / UUID)→ 按 external_id 查;
+        命中软删账本 / 不存在 → None
+      - 空 → 第一个**未软删**账本(按 created_at 升序)
     """
     if ledger_id:
         led = db.scalar(
@@ -48,14 +66,11 @@ def _resolve_ledger(
                 Ledger.external_id == ledger_id,
             )
         )
+        if led is None or _is_ledger_deleted(db, ledger_id=led.id):
+            return None
         return led
-    # fallback 第一个账本(按 created_at)
-    return db.scalar(
-        select(Ledger)
-        .where(Ledger.user_id == user_id)
-        .order_by(Ledger.created_at.asc())
-        .limit(1)
-    )
+    live = live_ledgers(db, user_id)
+    return live[0] if live else None
 
 
 def _serialize_tx(row: ReadTxProjection, category_name: str | None) -> dict[str, Any]:
@@ -77,13 +92,11 @@ def _serialize_tx(row: ReadTxProjection, category_name: str | None) -> dict[str,
 
 
 def list_ledgers(user: User) -> list[dict[str, Any]]:
-    """列出当前用户的所有账本。返回 external_id / name / currency / created_at。"""
+    """列出当前用户的所有账本(已排除软删账本,issue #31)。
+
+    返回 external_id / name / currency / created_at。
+    """
     with SessionLocal() as db:
-        rows = db.scalars(
-            select(Ledger)
-            .where(Ledger.user_id == user.id)
-            .order_by(Ledger.created_at.asc())
-        ).all()
         return [
             {
                 "id": r.external_id,
@@ -91,7 +104,7 @@ def list_ledgers(user: User) -> list[dict[str, Any]]:
                 "currency": r.currency,
                 "created_at": r.created_at.isoformat() if r.created_at else None,
             }
-            for r in rows
+            for r in live_ledgers(db, user.id)
         ]
 
 

--- a/src/mcp/tools/write_tools.py
+++ b/src/mcp/tools/write_tools.py
@@ -33,7 +33,7 @@ from ...models import (
     User,
 )
 from ...security import SCOPE_APP_WRITE, _create_token
-from .read_tools import _parse_dt, _resolve_ledger
+from .read_tools import _parse_dt, _resolve_ledger, live_ledgers
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +88,53 @@ async def _self_call(method: str, path: str, user: User, **kwargs: Any) -> dict[
         return {"_raw": resp.text}
 
 
+# ---------- ledger resolution for writes ------------------------------------
+
+
+def _resolve_write_ledger(
+    db, user: User, ledger_id: str | None
+) -> tuple[Ledger | None, dict[str, Any] | None]:
+    """为**写**操作解析目标账本。返回 ``(ledger, None)`` 表示成功;
+    ``(None, status_dict)`` 表示调用方 / LLM 必须先澄清,**不应写入**。
+
+    issue #31 两条规则:
+      - 软删账本不可作为写入目标(`_resolve_ledger` 已排除,B1/B2);
+      - 不指定 ``ledger_id`` 且有 **>1 个 live 账本**时**拒绝瞎猜**(B5):返回
+        候选列表,逼 LLM 显式带 ``ledger_id`` —— 避免静默落到"最早创建"的幽灵
+        默认账本(报告里"写进了不存在的默认账本"的根因)。
+
+    返回的 status_dict 跟 `delete_transaction` 的 ``confirmation_required`` 一样,
+    是给 LLM 看的结构化信号,不是错误。
+    """
+    if ledger_id:
+        led = _resolve_ledger(db, user.id, ledger_id)
+        if led is None:
+            return None, {
+                "status": "ledger_not_found",
+                "message": f"Ledger not found or has been deleted: {ledger_id}",
+                "ledger_id": ledger_id,
+            }
+        return led, None
+
+    live = live_ledgers(db, user.id)
+    if not live:
+        return None, {
+            "status": "no_ledger",
+            "message": "You have no ledger yet. Create one in BeeCount first.",
+        }
+    if len(live) == 1:
+        return live[0], None
+    return None, {
+        "status": "ledger_required",
+        "message": (
+            "You have multiple ledgers — refusing to guess which one to write to. "
+            "Re-call this tool with an explicit `ledger_id` (the `id` field of one "
+            "of the candidates below)."
+        ),
+        "candidates": [{"id": led.external_id, "name": led.name} for led in live],
+    }
+
+
 # ---------- tools -----------------------------------------------------------
 
 
@@ -110,9 +157,11 @@ async def create_transaction(
         raise ValueError("amount must be positive")
 
     with SessionLocal() as db:
-        led = _resolve_ledger(db, user.id, ledger_id)
-        if led is None:
-            raise ValueError(f"Ledger not found: {ledger_id}")
+        led, ledger_status = _resolve_write_ledger(db, user, ledger_id)
+        if ledger_status is not None:
+            # 多账本未指定 / 账本不存在或已删 —— 交回 LLM 澄清,不写入。
+            return ledger_status
+        assert led is not None  # 契约:_resolve_write_ledger 的 status 为 None ⟺ led 命中
         if category:
             _lookup_category_sync_id(db, user.id, category, tx_type)
         if account:
@@ -355,6 +404,121 @@ async def update_budget(
     return {"sync_id": budget_id, "amount": amount, "_meta": result}
 
 
+# 一次 self-call /transactions/batch 最多塞多少笔(端点自身上限 50)。
+_BATCH_CHUNK = 50
+# 单次 create_transactions 调用的总上限 —— 防 LLM 一次塞几千笔把单个 tool call
+# 拖死;超过让它分多次调。
+_BULK_MAX_TOTAL = 200
+
+
+async def create_transactions(
+    user: User,
+    *,
+    transactions: list[dict[str, Any]],
+    ledger_id: str | None = None,
+) -> dict[str, Any]:
+    """批量新建交易(Excel / 对账单导入等)。
+
+    比循环调 `create_transaction` 高效得多:走 server 的 `/transactions/batch`
+    端点,每 ≤50 笔**一次 commit + 一次 WS 广播**,避免 N 次全量 snapshot 重建
+    (issue #31 A3 —— 报告里"批量 MCP 写入服务端短时无响应 / 部分失败"的正解)。
+
+    每个 item 字段(跟 create_transaction 一致):
+      amount(必填 >0)、tx_type(expense|income|transfer,默认 expense)、
+      category、account、happened_at(ISO,缺省=now)、note、tags(list)。
+    """
+    if not transactions:
+        raise ValueError("transactions must be a non-empty list")
+    if len(transactions) > _BULK_MAX_TOTAL:
+        raise ValueError(
+            f"Too many transactions in one call ({len(transactions)} > "
+            f"{_BULK_MAX_TOTAL}). Split into multiple calls."
+        )
+
+    # 1. 解析 + 校验目标账本(B5:多账本不瞎猜)
+    with SessionLocal() as db:
+        led, ledger_status = _resolve_write_ledger(db, user, ledger_id)
+        if ledger_status is not None:
+            return ledger_status
+        assert led is not None  # 契约:_resolve_write_ledger 的 status 为 None ⟺ led 命中
+        ledger_external_id = led.external_id
+        ledger_name = led.name
+        led_internal_id = led.id
+
+    # 2. 规范化每笔 + 基础校验;收集要校验的 category / account 名
+    norm_items: list[dict[str, Any]] = []
+    cat_needed: set[str] = set()
+    acc_needed: set[str] = set()
+    for i, raw in enumerate(transactions):
+        amount = raw.get("amount")
+        tx_type = raw.get("tx_type") or "expense"
+        if tx_type not in {"expense", "income", "transfer"}:
+            raise ValueError(f"transactions[{i}]: invalid tx_type {tx_type!r}")
+        if not isinstance(amount, (int, float)) or isinstance(amount, bool) or amount <= 0:
+            raise ValueError(f"transactions[{i}]: amount must be a positive number")
+        happened_at = raw.get("happened_at")
+        happened = _parse_dt(happened_at) if happened_at else datetime.now(timezone.utc)
+        item: dict[str, Any] = {
+            "tx_type": tx_type,
+            "amount": float(amount),
+            "happened_at": happened.isoformat(),
+        }
+        if raw.get("note"):
+            item["note"] = str(raw["note"])
+        category = raw.get("category")
+        if category:
+            item["category_name"] = str(category)
+            item["category_kind"] = tx_type
+            cat_needed.add(str(category))
+        account = raw.get("account")
+        if account:
+            if tx_type == "transfer":
+                item["from_account_name"] = str(account)
+            else:
+                item["account_name"] = str(account)
+            acc_needed.add(str(account))
+        # 用户 tags ∪ MCP 默认标签;batch 端点按名建实体 / 反查 sync_id。
+        item["tags"] = _merge_default_tag(raw.get("tags"))
+        norm_items.append(item)
+
+    # 3. 预校验 category / account 名是否存在(O(1) 查询,给 LLM 清晰报错,
+    #    跟单笔 create_transaction 的 _lookup_* 校验同口径)
+    with SessionLocal() as db:
+        _validate_names_exist(db, user.id, categories=cat_needed, accounts=acc_needed)
+        mcp_tag_missing = _is_tag_missing_in_ledger(
+            db, user_id=user.id, ledger_id=led_internal_id, tag_name=_MCP_DEFAULT_TAG,
+        )
+
+    # 4. 确保 MCP tag 实体存在(带专属颜色),batch 端点随后复用同名 tag。
+    if mcp_tag_missing:
+        await _ensure_mcp_tag(user, ledger_external_id)
+
+    # 5. 分块 self-call /transactions/batch
+    settings = get_settings()
+    path = f"{settings.api_prefix}/write/ledgers/{ledger_external_id}/transactions/batch"
+    created_ids: list[str] = []
+    for start in range(0, len(norm_items), _BATCH_CHUNK):
+        chunk = norm_items[start : start + _BATCH_CHUNK]
+        result = await _self_call(
+            "POST",
+            path,
+            user,
+            json={
+                "base_change_id": 0,
+                "transactions": chunk,
+                "auto_ai_tag": False,  # MCP 用自己的 MCP 标签,不要"AI 记账"标签
+            },
+        )
+        created_ids.extend(result.get("created_sync_ids") or [])
+
+    return {
+        "status": "created",
+        "ledger": ledger_name,
+        "created_count": len(created_ids),
+        "sync_ids": created_ids,
+    }
+
+
 async def parse_and_create_from_text(
     user: User,
     *,
@@ -366,6 +530,15 @@ async def parse_and_create_from_text(
     LLM 偷懒选项 — 直接转发用户原话 → BeeCount AI parse → 自动 create。
     要求用户已配 AI chat provider(profile.ai_config_json),否则报错。
     """
+    # B5(issue #31):先把目标账本定死,多账本不指定则不猜(返回候选),也避免
+    # 拿一个软删 / 幽灵账本去跑 AI 解析。pin 到 external_id 后贯穿 parse + create。
+    with SessionLocal() as db:
+        led, ledger_status = _resolve_write_ledger(db, user, ledger_id)
+        if ledger_status is not None:
+            return ledger_status
+        assert led is not None  # 契约:_resolve_write_ledger 的 status 为 None ⟺ led 命中
+        ledger_id = led.external_id
+
     settings = get_settings()
     path = f"{settings.api_prefix}/ai/parse-tx-text"
     parsed = await _self_call(
@@ -493,6 +666,48 @@ def _merge_default_tag(tags: list[str] | None) -> list[str]:
 
 
 # ---------- internal lookups ------------------------------------------------
+
+
+def _validate_names_exist(
+    db, user_id: str, *, categories: set[str], accounts: set[str]
+) -> None:
+    """批量校验 category / account 名都存在(各一条 IN 查询),不存在的一次性报全。
+
+    给 create_transactions 用 —— 单笔 create 走 _lookup_* 逐个校验,批量则一次
+    查清,避免 N 次查询,且能在一条错误里列出所有未知名字。
+    """
+    if categories:
+        found = {
+            n
+            for (n,) in db.execute(
+                select(UserCategoryProjection.name).where(
+                    UserCategoryProjection.user_id == user_id,
+                    UserCategoryProjection.name.in_(categories),
+                )
+            ).all()
+        }
+        missing = sorted(categories - found)
+        if missing:
+            raise ValueError(
+                f"Unknown categories: {missing}. Use existing category names "
+                "(call list_categories) or create them first."
+            )
+    if accounts:
+        found = {
+            n
+            for (n,) in db.execute(
+                select(UserAccountProjection.name).where(
+                    UserAccountProjection.user_id == user_id,
+                    UserAccountProjection.name.in_(accounts),
+                )
+            ).all()
+        }
+        missing = sorted(accounts - found)
+        if missing:
+            raise ValueError(
+                f"Unknown accounts: {missing}. Use existing account names "
+                "(call list_accounts)."
+            )
 
 
 def _lookup_category_sync_id(db, user_id: str, name: str | None, tx_type: str | None) -> str | None:

--- a/src/routers/read/_shared.py
+++ b/src/routers/read/_shared.py
@@ -262,6 +262,47 @@ def _is_ledger_deleted(db: Session, *, ledger_id: str) -> bool:
     return latest_action == "delete"
 
 
+def _visible_workspace_ledgers(
+    db: Session,
+    *,
+    current_user: User,
+    is_admin: bool,
+    ledger_id: str | None = None,
+    user_id: str | None = None,
+) -> list[Ledger]:
+    """workspace.py 跨账本聚合端点共用的账本可见性解析。
+
+    统一三件事(此前 7 个端点各自 copy-paste 一份 ledger_conditions):
+      - ``ledger_id``(external_id)限定单账本;
+      - admin + ``user_id`` 限定某用户;非 admin 走 ``LedgerMember``;
+      - **排除软删账本**(issue #31):软删账本被写入"复活"出来的交易不应再出现
+        在跨账本 / tag / 统计视图里 —— 跟 ``/read/ledgers`` 的 `_is_ledger_deleted`
+        过滤口径保持一致(此前 workspace 不过滤,导致"tag 里看得到、账本列表里
+        却没有"的幽灵交易)。
+    """
+    conditions: list[Any] = []
+    if ledger_id:
+        conditions.append(Ledger.external_id == ledger_id)
+    if is_admin:
+        if user_id:
+            conditions.append(Ledger.user_id == user_id)
+    else:
+        # 共享账本:走 LedgerMember 维度,Editor 也能看到 Owner 的账本数据。
+        conditions.append(
+            Ledger.id.in_(
+                select(LedgerMember.ledger_id).where(
+                    LedgerMember.user_id == current_user.id
+                )
+            )
+        )
+    ledgers = list(
+        db.execute(
+            select(Ledger).where(and_(*conditions) if conditions else true())
+        ).scalars().all()
+    )
+    return [lg for lg in ledgers if not _is_ledger_deleted(db, ledger_id=lg.id)]
+
+
 def _snapshot_ledger_info(
     snapshot: dict[str, Any] | None,
     *,
@@ -604,6 +645,7 @@ __all__ = [
     '_owner_map_for_ledgers',
     '_user_info_map',
     '_is_ledger_deleted',
+    '_visible_workspace_ledgers',
     '_snapshot_ledger_info',
     '_resolve_ledger_name',
     '_load_owner_identity',

--- a/src/routers/read/workspace.py
+++ b/src/routers/read/workspace.py
@@ -33,25 +33,11 @@ def list_workspace_transactions(
 ) -> WorkspaceTransactionPageOut:
     is_admin = _is_admin(current_user)
 
-    # 账本筛选 → 内部 id 列表,projection 用 internal id 对账
-    ledger_conditions: list[Any] = []
-    if ledger_id:
-        ledger_conditions.append(Ledger.external_id == ledger_id)
-    if is_admin:
-        if user_id:
-            ledger_conditions.append(Ledger.user_id == user_id)
-    else:
-        # 共享账本:走 LedgerMember 维度,Editor 也能看到 Owner 的账本数据。
-        ledger_conditions.append(
-            Ledger.id.in_(
-                select(LedgerMember.ledger_id).where(
-                    LedgerMember.user_id == current_user.id
-                )
-            )
-        )
-    ledgers = list(db.execute(
-        select(Ledger).where(and_(*ledger_conditions) if ledger_conditions else true())
-    ).scalars().all())
+    # 账本筛选 → 内部 id 列表(已排除软删账本,issue #31)
+    ledgers = _visible_workspace_ledgers(
+        db, current_user=current_user, is_admin=is_admin,
+        ledger_id=ledger_id, user_id=user_id,
+    )
     if not ledgers:
         return WorkspaceTransactionPageOut(items=[], total=0, limit=limit, offset=offset)
 
@@ -320,25 +306,11 @@ def export_workspace_transactions_csv(
     headers = _CSV_HEADERS_BY_LANG[lang_key]
     type_labels = _TX_TYPE_LABELS_BY_LANG[lang_key]
 
-    # 账本筛选 — 跟 list_workspace_transactions 完全一致
-    ledger_conditions: list[Any] = []
-    if ledger_id:
-        ledger_conditions.append(Ledger.external_id == ledger_id)
-    if is_admin:
-        if user_id:
-            ledger_conditions.append(Ledger.user_id == user_id)
-    else:
-        # 共享账本:走 LedgerMember 维度,Editor 也能看到 Owner 的账本数据。
-        ledger_conditions.append(
-            Ledger.id.in_(
-                select(LedgerMember.ledger_id).where(
-                    LedgerMember.user_id == current_user.id
-                )
-            )
-        )
-    ledgers = list(db.execute(
-        select(Ledger).where(and_(*ledger_conditions) if ledger_conditions else true())
-    ).scalars().all())
+    # 账本筛选 — 跟 list_workspace_transactions 完全一致(含软删过滤,issue #31)
+    ledgers = _visible_workspace_ledgers(
+        db, current_user=current_user, is_admin=is_admin,
+        ledger_id=ledger_id, user_id=user_id,
+    )
 
     if ledgers:
         ledger_internal_ids = [l.id for l in ledgers]
@@ -540,28 +512,11 @@ def list_workspace_accounts(
 ) -> list[WorkspaceAccountOut]:
     is_admin = _is_admin(current_user)
 
-    # --- 1. 从 snapshot 聚合账户（手机同步写入的数据） ---
-    ledger_conditions: list[Any] = []
-    if ledger_id:
-        ledger_conditions.append(Ledger.external_id == ledger_id)
-    if is_admin:
-        if user_id:
-            ledger_conditions.append(Ledger.user_id == user_id)
-    else:
-        # 共享账本:走 LedgerMember 维度,Editor 也能看到 Owner 的账本数据。
-        ledger_conditions.append(
-            Ledger.id.in_(
-                select(LedgerMember.ledger_id).where(
-                    LedgerMember.user_id == current_user.id
-                )
-            )
-        )
-
-    ledgers = db.execute(
-        select(Ledger).where(and_(*ledger_conditions) if ledger_conditions else true())
-    ).scalars().all()
-
-    ledgers = list(ledgers)
+    # --- 1. 从 snapshot 聚合账户（手机同步写入的数据，已排除软删账本 issue #31） ---
+    ledgers = _visible_workspace_ledgers(
+        db, current_user=current_user, is_admin=is_admin,
+        ledger_id=ledger_id, user_id=user_id,
+    )
     if not ledgers:
         return []
     ledger_internal_ids = [l.id for l in ledgers]
@@ -711,28 +666,11 @@ def list_workspace_categories(
 ) -> list[WorkspaceCategoryOut]:
     is_admin = _is_admin(current_user)
 
-    # --- 1. 从 snapshot 聚合分类（手机同步写入的数据） ---
-    ledger_conditions: list[Any] = []
-    if ledger_id:
-        ledger_conditions.append(Ledger.external_id == ledger_id)
-    if is_admin:
-        if user_id:
-            ledger_conditions.append(Ledger.user_id == user_id)
-    else:
-        # 共享账本:走 LedgerMember 维度,Editor 也能看到 Owner 的账本数据。
-        ledger_conditions.append(
-            Ledger.id.in_(
-                select(LedgerMember.ledger_id).where(
-                    LedgerMember.user_id == current_user.id
-                )
-            )
-        )
-
-    ledgers = db.execute(
-        select(Ledger).where(and_(*ledger_conditions) if ledger_conditions else true())
-    ).scalars().all()
-
-    ledgers = list(ledgers)
+    # --- 1. 从 snapshot 聚合分类（手机同步写入的数据，已排除软删账本 issue #31） ---
+    ledgers = _visible_workspace_ledgers(
+        db, current_user=current_user, is_admin=is_admin,
+        ledger_id=ledger_id, user_id=user_id,
+    )
     if not ledgers:
         return []
     ledger_internal_ids = [l.id for l in ledgers]
@@ -827,30 +765,13 @@ def list_workspace_tags(
 ) -> list[WorkspaceTagOut]:
     is_admin = _is_admin(current_user)
 
-    # --- 1. 从 snapshot 聚合标签（手机同步写入的数据） ---
-    ledger_conditions: list[Any] = []
-    if ledger_id:
-        ledger_conditions.append(Ledger.external_id == ledger_id)
-    if is_admin:
-        if user_id:
-            ledger_conditions.append(Ledger.user_id == user_id)
-    else:
-        # 共享账本:走 LedgerMember 维度,Editor 也能看到 Owner 的账本数据。
-        ledger_conditions.append(
-            Ledger.id.in_(
-                select(LedgerMember.ledger_id).where(
-                    LedgerMember.user_id == current_user.id
-                )
-            )
-        )
-
-    ledgers = db.execute(
-        select(Ledger).where(and_(*ledger_conditions) if ledger_conditions else true())
-    ).scalars().all()
+    # --- 1. 从 snapshot 聚合标签（手机同步写入的数据，已排除软删账本 issue #31） ---
+    ledgers = _visible_workspace_ledgers(
+        db, current_user=current_user, is_admin=is_admin,
+        ledger_id=ledger_id, user_id=user_id,
+    )
 
     all_tags: list[WorkspaceTagOut] = []
-
-    ledgers = list(ledgers)
     # user-global 重构:tag 是 per-user。即便用户无 ledger,标签仍可存在(协议层
     # 允许);但 tx 聚合需要 ledger 才有意义,所以 stats 阶段空集即可。
     ledger_internal_ids = [l.id for l in ledgers]
@@ -959,25 +880,10 @@ def workspace_ledger_counts(
     `COUNT(*) + julianday(now) - julianday(MIN(happened_at))`)。不限时间范围。
     首页 Hero 用来展示"记账笔数 / 记账天数"，与 analytics 的 scope=year 脱钩。"""
     is_admin = _is_admin(current_user)
-    ledger_conditions: list[Any] = []
-    if ledger_id:
-        ledger_conditions.append(Ledger.external_id == ledger_id)
-    if is_admin:
-        if user_id:
-            ledger_conditions.append(Ledger.user_id == user_id)
-    else:
-        # 共享账本:走 LedgerMember 维度,Editor 也能看到 Owner 的账本数据。
-        ledger_conditions.append(
-            Ledger.id.in_(
-                select(LedgerMember.ledger_id).where(
-                    LedgerMember.user_id == current_user.id
-                )
-            )
-        )
-
-    ledgers = list(db.execute(
-        select(Ledger).where(and_(*ledger_conditions) if ledger_conditions else true())
-    ).scalars().all())
+    ledgers = _visible_workspace_ledgers(
+        db, current_user=current_user, is_admin=is_admin,
+        ledger_id=ledger_id, user_id=user_id,
+    )
     ledger_internal_ids = [l.id for l in ledgers]
     if not ledger_internal_ids:
         return WorkspaceLedgerCountsOut(
@@ -1036,25 +942,10 @@ def workspace_analytics(
         scope=scope, period=period, tz_offset_minutes=tz_offset_minutes,
     )
 
-    ledger_conditions: list[Any] = []
-    if ledger_id:
-        ledger_conditions.append(Ledger.external_id == ledger_id)
-    if is_admin:
-        if user_id:
-            ledger_conditions.append(Ledger.user_id == user_id)
-    else:
-        # 共享账本:走 LedgerMember 维度,Editor 也能看到 Owner 的账本数据。
-        ledger_conditions.append(
-            Ledger.id.in_(
-                select(LedgerMember.ledger_id).where(
-                    LedgerMember.user_id == current_user.id
-                )
-            )
-        )
-
-    ledgers = list(db.execute(
-        select(Ledger).where(and_(*ledger_conditions) if ledger_conditions else true())
-    ).scalars().all())
+    ledgers = _visible_workspace_ledgers(
+        db, current_user=current_user, is_admin=is_admin,
+        ledger_id=ledger_id, user_id=user_id,
+    )
     ledger_internal_ids = [l.id for l in ledgers]
 
     transaction_count = 0

--- a/src/routers/write/_shared.py
+++ b/src/routers/write/_shared.py
@@ -30,6 +30,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from sqlalchemy import delete, func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+from starlette.concurrency import run_in_threadpool
 
 from ...concurrency import lock_ledger_for_materialize
 from ...config import get_settings
@@ -436,6 +437,18 @@ def _load_ledger_for_write(
         roles=roles,
     )
     if row is not None:
+        # issue #31(B2):软删账本不可写。否则一次写入就"复活"它的 projection,
+        # 产生 web 账本列表看不见、tag / 跨账本视图里却查得到、又没 UI 入口去删
+        # 的幽灵交易。软删后无法用同 external_id 重建(create_ledger 命中既有行
+        # 直接 409),所以这里跟 read 端 _is_ledger_deleted 同口径直接 404,不会
+        # 误伤任何合法重建流程。late import 防循环。
+        from ..read._shared import _is_ledger_deleted
+
+        ledger = row[0]
+        if _is_ledger_deleted(db, ledger_id=ledger.id):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Ledger not found"
+            )
         return row
     raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ledger not found")
 
@@ -516,7 +529,7 @@ def _load_idempotent_response(
     return WriteCommitMeta.model_validate(payload)
 
 
-async def _commit_write_fast_tx(
+async def _commit_create_tx_fast(
     *,
     request: Request,
     db: Session,
@@ -527,65 +540,28 @@ async def _commit_write_fast_tx(
     idempotency_key: str | None,
     device_id: str,
     audit_action: str,
-    tx_id: str,
     mutate_payload: dict,
-    action: str,  # "upsert" | "delete"
 ) -> WriteCommitMeta:
-    """Fast path:单 tx update/delete,跳过全 snapshot build。只 SELECT 目标 tx
-    (1 条 query by PK)→ 合并 payload → 写 SyncChange + projection。~10-15ms。
+    """Fast path:新建单笔 tx,跳过全量 snapshot build(issue #31 A1b)。
+
+    create 不需要 diff 全表 —— 新行就是唯一变更。snapshot_mutator.create_transaction
+    不依赖现有 items / tx_index,所以用空的最小 snapshot 跑它产出规范化 item,直接
+    emit 一条 transaction SyncChange + projection.upsert_tx。语义跟 _commit_write
+    (build→mutate→_emit_entity_diffs)对单笔 create 的结果完全一致,但把成本从
+    O(账本交易数) 降到 O(1)。
+
+    DB 工作整段丢到 threadpool(issue #31 A2),不阻塞 event loop;WS 广播在
+    线程返回后于 loop 上做(仅一次小的 member 查询 + 推送)。
     """
-    lock_ledger_for_materialize(db, ledger.id)
-    now = _utcnow()
+    from ...snapshot_mutator import create_transaction as _mutate_create_tx
 
-    # 1. 读目标 tx from projection
-    tx_row = db.scalar(
-        select(ReadTxProjection).where(
-            ReadTxProjection.ledger_id == ledger.id,
-            ReadTxProjection.sync_id == tx_id,
-        )
-    )
-    if tx_row is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
-
-    # 2. 把 projection row → dict(mutator 认的 snapshot item 格式)
-    prev_item = _projection_row_to_tx_dict(tx_row)
-
-    # 3. actor 权限检查(复用现有逻辑)
-    from ...snapshot_mutator import _assert_actor_can_modify  # 延迟 import 避免循环
-    try:
-        _assert_actor_can_modify(prev_item, mutate_payload)
-    except PermissionError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
-
-    if action == "delete":
-        # 删 tx 前收集引用的 cloudFileId,删后 GC 孤立附件(物理 blob + 行)
-        tx_file_ids = projection.collect_tx_attachment_fileids(
-            db, ledger_id=ledger.id, sync_id=tx_id,
-        )
-        change_row = SyncChange(
-            user_id=ledger.user_id,
-            ledger_id=ledger.id,
-            entity_type="transaction",
-            entity_sync_id=tx_id,
-            action="delete",
-            payload_json={},
-            updated_at=now,
-            updated_by_device_id=device_id,
-            updated_by_user_id=current_user.id,
-        )
-        db.add(change_row)
-        db.flush()
-        projection.delete_tx(db, ledger_id=ledger.id, sync_id=tx_id)
-        projection.gc_orphan_attachments(
-            db, user_id=ledger.user_id, file_ids=tx_file_ids,
-        )
-    else:
-        # Upsert:merge payload 到 prev_item
-        from ...snapshot_mutator import update_transaction
-        # 构造最小 snapshot 让 mutator 跑逻辑(只有 1 个 item)
-        minimal_snap = {"items": [prev_item], "count": 1}
-        minimal_snap = update_transaction(minimal_snap, tx_id, mutate_payload)
-        new_item = minimal_snap["items"][0]
+    def _core() -> tuple[WriteCommitMeta, bool]:
+        """同步 DB 核心,返回 (response, did_replay)。在 worker thread 里跑。"""
+        lock_ledger_for_materialize(db, ledger.id)
+        now = _utcnow()
+        # 空 snapshot 跑 mutator —— 只为复用其字段规范化 + actor 标记逻辑。
+        _snap, tx_id = _mutate_create_tx({"items": [], "count": 0}, mutate_payload)
+        new_item = _snap["items"][0]
 
         change_row = SyncChange(
             user_id=ledger.user_id,
@@ -608,78 +584,257 @@ async def _commit_write_fast_tx(
             payload=new_item,
         )
 
-    new_change_id = change_row.change_id
+        db.add(
+            AuditLog(
+                user_id=current_user.id,
+                ledger_id=ledger.id,
+                action=audit_action,
+                metadata_json={
+                    "ledgerId": ledger.external_id,
+                    "baseChangeId": base_change_id,
+                    "newChangeId": change_row.change_id,
+                    "entityId": tx_id,
+                },
+            )
+        )
 
-    db.add(
-        AuditLog(
-            user_id=current_user.id,
+        response = WriteCommitMeta(
+            ledger_id=ledger.external_id,
+            base_change_id=base_change_id,
+            new_change_id=change_row.change_id,
+            server_timestamp=now,
+            idempotency_replayed=False,
+            entity_id=tx_id,
+        )
+
+        request_hash = _hash_request(request.method, request.url.path, request_payload)
+        if idempotency_key:
+            db.add(
+                SyncPushIdempotency(
+                    user_id=current_user.id,
+                    device_id=device_id,
+                    idempotency_key=idempotency_key,
+                    request_hash=request_hash,
+                    response_json=response.model_dump(mode="json"),
+                    created_at=now,
+                    expires_at=now + timedelta(hours=24),
+                )
+            )
+
+        try:
+            db.commit()
+        except IntegrityError:
+            db.rollback()
+            if idempotency_key:
+                replay = _load_idempotent_response(
+                    db,
+                    user_id=current_user.id,
+                    device_id=device_id,
+                    idempotency_key=idempotency_key,
+                    request_hash=request_hash,
+                )
+                if replay is not None:
+                    return replay, True
+            raise
+        return response, False
+
+    response, did_replay = await run_in_threadpool(_core)
+
+    if not did_replay:
+        from ...websocket_manager import broadcast_to_ledger
+
+        await broadcast_to_ledger(
+            db=db,
+            ws_manager=request.app.state.ws_manager,
             ledger_id=ledger.id,
-            action=audit_action,
-            metadata_json={
+            payload={
+                "type": "sync_change",
                 "ledgerId": ledger.external_id,
-                "baseChangeId": base_change_id,
-                "newChangeId": new_change_id,
-                "entityId": tx_id,
+                "serverCursor": response.new_change_id,
+                "serverTimestamp": response.server_timestamp.isoformat(),
             },
         )
+    logger.info(
+        "write.commit.create_fast ledger=%s entity=%s change_id=%d device=%s user=%s replay=%s",
+        ledger.external_id, response.entity_id, response.new_change_id,
+        device_id, current_user.id, did_replay,
     )
+    return response
 
-    response = WriteCommitMeta(
-        ledger_id=ledger.external_id,
-        base_change_id=base_change_id,
-        new_change_id=new_change_id,
-        server_timestamp=now,
-        idempotency_replayed=False,
-        entity_id=tx_id,
-    )
 
-    request_hash = _hash_request(request.method, request.url.path, request_payload)
-    if idempotency_key:
+async def _commit_write_fast_tx(
+    *,
+    request: Request,
+    db: Session,
+    current_user: User,
+    ledger: Ledger,
+    base_change_id: int,
+    request_payload: dict,
+    idempotency_key: str | None,
+    device_id: str,
+    audit_action: str,
+    tx_id: str,
+    mutate_payload: dict,
+    action: str,  # "upsert" | "delete"
+) -> WriteCommitMeta:
+    """Fast path:单 tx update/delete,跳过全 snapshot build。只 SELECT 目标 tx
+    (1 条 query by PK)→ 合并 payload → 写 SyncChange + projection。~10-15ms。
+
+    DB 工作整段丢 threadpool(issue #31 A2),不阻塞 event loop;广播在线程返回后做。
+    """
+
+    def _core() -> tuple[WriteCommitMeta, bool]:
+        """同步 DB 核心,返回 (response, did_replay)。在 worker thread 里跑。"""
+        lock_ledger_for_materialize(db, ledger.id)
+        now = _utcnow()
+
+        # 1. 读目标 tx from projection
+        tx_row = db.scalar(
+            select(ReadTxProjection).where(
+                ReadTxProjection.ledger_id == ledger.id,
+                ReadTxProjection.sync_id == tx_id,
+            )
+        )
+        if tx_row is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
+
+        # 2. 把 projection row → dict(mutator 认的 snapshot item 格式)
+        prev_item = _projection_row_to_tx_dict(tx_row)
+
+        # 3. actor 权限检查(复用现有逻辑)
+        from ...snapshot_mutator import _assert_actor_can_modify  # 延迟 import 避免循环
+        try:
+            _assert_actor_can_modify(prev_item, mutate_payload)
+        except PermissionError as exc:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+
+        if action == "delete":
+            # 删 tx 前收集引用的 cloudFileId,删后 GC 孤立附件(物理 blob + 行)
+            tx_file_ids = projection.collect_tx_attachment_fileids(
+                db, ledger_id=ledger.id, sync_id=tx_id,
+            )
+            change_row = SyncChange(
+                user_id=ledger.user_id,
+                ledger_id=ledger.id,
+                entity_type="transaction",
+                entity_sync_id=tx_id,
+                action="delete",
+                payload_json={},
+                updated_at=now,
+                updated_by_device_id=device_id,
+                updated_by_user_id=current_user.id,
+            )
+            db.add(change_row)
+            db.flush()
+            projection.delete_tx(db, ledger_id=ledger.id, sync_id=tx_id)
+            projection.gc_orphan_attachments(
+                db, user_id=ledger.user_id, file_ids=tx_file_ids,
+            )
+        else:
+            # Upsert:merge payload 到 prev_item
+            from ...snapshot_mutator import update_transaction
+            # 构造最小 snapshot 让 mutator 跑逻辑(只有 1 个 item)
+            minimal_snap = {"items": [prev_item], "count": 1}
+            minimal_snap = update_transaction(minimal_snap, tx_id, mutate_payload)
+            new_item = minimal_snap["items"][0]
+
+            change_row = SyncChange(
+                user_id=ledger.user_id,
+                ledger_id=ledger.id,
+                entity_type="transaction",
+                entity_sync_id=tx_id,
+                action="upsert",
+                payload_json=new_item,
+                updated_at=now,
+                updated_by_device_id=device_id,
+                updated_by_user_id=current_user.id,
+            )
+            db.add(change_row)
+            db.flush()
+            projection.upsert_tx(
+                db,
+                ledger_id=ledger.id,
+                user_id=ledger.user_id,
+                source_change_id=change_row.change_id,
+                payload=new_item,
+            )
+
+        new_change_id = change_row.change_id
+
         db.add(
-            SyncPushIdempotency(
+            AuditLog(
                 user_id=current_user.id,
-                device_id=device_id,
-                idempotency_key=idempotency_key,
-                request_hash=request_hash,
-                response_json=response.model_dump(mode="json"),
-                created_at=now,
-                expires_at=now + timedelta(hours=24),
+                ledger_id=ledger.id,
+                action=audit_action,
+                metadata_json={
+                    "ledgerId": ledger.external_id,
+                    "baseChangeId": base_change_id,
+                    "newChangeId": new_change_id,
+                    "entityId": tx_id,
+                },
             )
         )
 
-    try:
-        db.commit()
-    except IntegrityError as exc:
-        db.rollback()
-        if idempotency_key:
-            replay = _load_idempotent_response(
-                db,
-                user_id=current_user.id,
-                device_id=device_id,
-                idempotency_key=idempotency_key,
-                request_hash=request_hash,
-            )
-            if replay is not None:
-                return replay
-        raise exc
+        response = WriteCommitMeta(
+            ledger_id=ledger.external_id,
+            base_change_id=base_change_id,
+            new_change_id=new_change_id,
+            server_timestamp=now,
+            idempotency_replayed=False,
+            entity_id=tx_id,
+        )
 
-    # 共享账本:fan-out 给所有 LedgerMember(非只 owner)。否则 web/Owner 写
-    # tx,Editor 端 mobile 收不到 sync_change WS,要重启 app 才能看到新数据。
-    from ...websocket_manager import broadcast_to_ledger
-    await broadcast_to_ledger(
-        db=db,
-        ws_manager=request.app.state.ws_manager,
-        ledger_id=ledger.id,
-        payload={
-            "type": "sync_change",
-            "ledgerId": ledger.external_id,
-            "serverCursor": response.new_change_id,
-            "serverTimestamp": response.server_timestamp.isoformat(),
-        },
-    )
+        request_hash = _hash_request(request.method, request.url.path, request_payload)
+        if idempotency_key:
+            db.add(
+                SyncPushIdempotency(
+                    user_id=current_user.id,
+                    device_id=device_id,
+                    idempotency_key=idempotency_key,
+                    request_hash=request_hash,
+                    response_json=response.model_dump(mode="json"),
+                    created_at=now,
+                    expires_at=now + timedelta(hours=24),
+                )
+            )
+
+        try:
+            db.commit()
+        except IntegrityError as exc:
+            db.rollback()
+            if idempotency_key:
+                replay = _load_idempotent_response(
+                    db,
+                    user_id=current_user.id,
+                    device_id=device_id,
+                    idempotency_key=idempotency_key,
+                    request_hash=request_hash,
+                )
+                if replay is not None:
+                    return replay, True
+            raise exc
+        return response, False
+
+    response, did_replay = await run_in_threadpool(_core)
+
+    if not did_replay:
+        # 共享账本:fan-out 给所有 LedgerMember(非只 owner)。否则 web/Owner 写
+        # tx,Editor 端 mobile 收不到 sync_change WS,要重启 app 才能看到新数据。
+        from ...websocket_manager import broadcast_to_ledger
+        await broadcast_to_ledger(
+            db=db,
+            ws_manager=request.app.state.ws_manager,
+            ledger_id=ledger.id,
+            payload={
+                "type": "sync_change",
+                "ledgerId": ledger.external_id,
+                "serverCursor": response.new_change_id,
+                "serverTimestamp": response.server_timestamp.isoformat(),
+            },
+        )
     logger.info(
-        "write.commit.fast action=%s ledger=%s entity=%s change_id=%d device=%s user=%s",
-        audit_action, ledger.external_id, tx_id, response.new_change_id, device_id, current_user.id,
+        "write.commit.fast action=%s ledger=%s entity=%s change_id=%d device=%s user=%s replay=%s",
+        audit_action, ledger.external_id, tx_id, response.new_change_id, device_id, current_user.id, did_replay,
     )
     return response
 
@@ -749,126 +904,135 @@ async def _commit_write(
     audit_action: str,
     mutate: Callable[[dict], tuple[dict, str | None]],
 ) -> WriteCommitMeta:
-    # Serialize concurrent writers on the same ledger。方案 B 后不再写 snapshot,
-    # 但依然锁 —— 防止 rename cascade 的 SQL UPDATE 和 tx upsert 交叉跑。
-    lock_ledger_for_materialize(db, ledger.id)
+    # DB 工作整段丢 threadpool(issue #31 A2),不阻塞 event loop;两类 WS 广播
+    # 在线程返回后于 loop 上做。_core 返回 (response, did_replay, user_global_events)。
+    def _core() -> tuple[WriteCommitMeta, bool, list]:
+        # Serialize concurrent writers on the same ledger。方案 B 后不再写 snapshot,
+        # 但依然锁 —— 防止 rename cascade 的 SQL UPDATE 和 tx upsert 交叉跑。
+        lock_ledger_for_materialize(db, ledger.id)
 
-    # strict_base_change_id 语义转换:原先比 latest ledger_snapshot.change_id,
-    # 方案 B 后 snapshot 不再写,改比 ledger 上任意 entity 的最新 change_id
-    # (更严格 —— 连 tx 级修改都会触发 409)。默认关闭的 feature flag,生产用不到。
-    #
-    # 动态读 get_settings() 而不是缓存模块级 `settings`,是为了让测试 flip
-    # STRICT_BASE_CHANGE_ID + get_settings.cache_clear() 的方式能立刻生效
-    # (否则写入包分多个文件后,importlib.reload 不会重新执行 _shared.py
-    # 的 module-level `settings = get_settings()`,flag 读的永远是旧值)。
-    if get_settings().strict_base_change_id:
-        latest_any_change_id = snapshot_builder.latest_change_id(db, ledger.id)
-        if base_change_id != latest_any_change_id:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail={
-                    "message": "Write conflict",
-                    "latest_change_id": latest_any_change_id,
+        # strict_base_change_id 语义转换:原先比 latest ledger_snapshot.change_id,
+        # 方案 B 后 snapshot 不再写,改比 ledger 上任意 entity 的最新 change_id
+        # (更严格 —— 连 tx 级修改都会触发 409)。默认关闭的 feature flag,生产用不到。
+        if get_settings().strict_base_change_id:
+            latest_any_change_id = snapshot_builder.latest_change_id(db, ledger.id)
+            if base_change_id != latest_any_change_id:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={
+                        "message": "Write conflict",
+                        "latest_change_id": latest_any_change_id,
+                    },
+                )
+
+        # 从 projection 按需构建当前状态给 mutator 吃。这个 snapshot dict 不写回 DB ——
+        # 只是 mutator 内部用来查当前实体、做 duplicate/actor 校验。
+        snapshot = snapshot_builder.build(db, ledger)
+        # Shallow-per-entity copy for diffing(mutator 会原地改 items[i] 等)
+        prev_snapshot = {**snapshot}
+        for _k in ("items", "accounts", "categories", "tags", "budgets"):
+            arr = snapshot.get(_k)
+            if isinstance(arr, list):
+                prev_snapshot[_k] = [dict(e) if isinstance(e, dict) else e for e in arr]
+        try:
+            next_snapshot, entity_id = mutate(snapshot)
+        except KeyError:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Entity not found") from None
+        except PermissionError as exc:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+        now = _utcnow()
+        # 不再写 ledger_snapshot 行。emit 个体 SyncChange + 同事务 projection 写入,
+        # new_change_id 用 emit 出来的最后一条 SyncChange 的 change_id。
+        emitted_change_ids = _emit_entity_diffs(
+            db,
+            ledger=ledger,
+            current_user=current_user,
+            device_id=device_id,
+            prev=prev_snapshot,
+            next_snapshot=next_snapshot,
+            now=now,
+        )
+        # 无变化 → 用当前 max change_id(幂等/只是触发写但没真修改的场景)
+        new_change_id = max(emitted_change_ids) if emitted_change_ids else (
+            snapshot_builder.latest_change_id(db, ledger.id)
+        )
+
+        db.add(
+            AuditLog(
+                user_id=current_user.id,
+                ledger_id=ledger.id,
+                action=audit_action,
+                metadata_json={
+                    "ledgerId": ledger.external_id,
+                    "baseChangeId": base_change_id,
+                    "newChangeId": new_change_id,
+                    "entityId": entity_id,
                 },
             )
-
-    # 从 projection 按需构建当前状态给 mutator 吃。这个 snapshot dict 不写回 DB ——
-    # 只是 mutator 内部用来查当前实体、做 duplicate/actor 校验。
-    snapshot = snapshot_builder.build(db, ledger)
-    # Shallow-per-entity copy for diffing(mutator 会原地改 items[i] 等)
-    prev_snapshot = {**snapshot}
-    for _k in ("items", "accounts", "categories", "tags", "budgets"):
-        arr = snapshot.get(_k)
-        if isinstance(arr, list):
-            prev_snapshot[_k] = [dict(e) if isinstance(e, dict) else e for e in arr]
-    try:
-        next_snapshot, entity_id = mutate(snapshot)
-    except KeyError:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Entity not found") from None
-    except PermissionError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
-
-    now = _utcnow()
-    # 不再写 ledger_snapshot 行。emit 个体 SyncChange + 同事务 projection 写入,
-    # new_change_id 用 emit 出来的最后一条 SyncChange 的 change_id。
-    emitted_change_ids = _emit_entity_diffs(
-        db,
-        ledger=ledger,
-        current_user=current_user,
-        device_id=device_id,
-        prev=prev_snapshot,
-        next_snapshot=next_snapshot,
-        now=now,
-    )
-    # 无变化 → 用当前 max change_id(幂等/只是触发写但没真修改的场景)
-    new_change_id = max(emitted_change_ids) if emitted_change_ids else (
-        snapshot_builder.latest_change_id(db, ledger.id)
-    )
-
-    db.add(
-        AuditLog(
-            user_id=current_user.id,
-            ledger_id=ledger.id,
-            action=audit_action,
-            metadata_json={
-                "ledgerId": ledger.external_id,
-                "baseChangeId": base_change_id,
-                "newChangeId": new_change_id,
-                "entityId": entity_id,
-            },
-        )
-    )
-
-    response = WriteCommitMeta(
-        ledger_id=ledger.external_id,
-        base_change_id=base_change_id,
-        new_change_id=new_change_id,
-        server_timestamp=now,
-        idempotency_replayed=False,
-        entity_id=entity_id,
-    )
-
-    request_hash = _hash_request(request.method, request.url.path, request_payload)
-    if idempotency_key:
-        db.add(
-            SyncPushIdempotency(
-                user_id=current_user.id,
-                device_id=device_id,
-                idempotency_key=idempotency_key,
-                request_hash=request_hash,
-                response_json=response.model_dump(mode="json"),
-                created_at=now,
-                expires_at=now + timedelta(hours=24),
-            )
         )
 
-    try:
-        db.commit()
-    except IntegrityError as exc:
-        db.rollback()
+        response = WriteCommitMeta(
+            ledger_id=ledger.external_id,
+            base_change_id=base_change_id,
+            new_change_id=new_change_id,
+            server_timestamp=now,
+            idempotency_replayed=False,
+            entity_id=entity_id,
+        )
+
+        request_hash = _hash_request(request.method, request.url.path, request_payload)
         if idempotency_key:
-            replay = _load_idempotent_response(
-                db,
-                user_id=current_user.id,
-                device_id=device_id,
-                idempotency_key=idempotency_key,
-                request_hash=request_hash,
+            db.add(
+                SyncPushIdempotency(
+                    user_id=current_user.id,
+                    device_id=device_id,
+                    idempotency_key=idempotency_key,
+                    request_hash=request_hash,
+                    response_json=response.model_dump(mode="json"),
+                    created_at=now,
+                    expires_at=now + timedelta(hours=24),
+                )
             )
-            if replay is not None:
-                return replay
-        raise exc
 
-    logger.info(
-        "write.commit action=%s ledger=%s entity=%s change_id=%d device=%s user=%s",
-        audit_action,
-        ledger.external_id,
-        entity_id,
-        response.new_change_id,
-        device_id,
-        current_user.id,
-    )
+        try:
+            db.commit()
+        except IntegrityError as exc:
+            db.rollback()
+            if idempotency_key:
+                replay = _load_idempotent_response(
+                    db,
+                    user_id=current_user.id,
+                    device_id=device_id,
+                    idempotency_key=idempotency_key,
+                    request_hash=request_hash,
+                )
+                if replay is not None:
+                    return replay, True, []
+            raise exc
+
+        logger.info(
+            "write.commit action=%s ledger=%s entity=%s change_id=%d device=%s user=%s",
+            audit_action,
+            ledger.external_id,
+            entity_id,
+            response.new_change_id,
+            device_id,
+            current_user.id,
+        )
+        # §7 共享账本:user-global 实体(category/account/tag)的 shared_resource
+        # fan-out 输入。纯 diff(sync),在线程里算好,出去再 await 推送。
+        user_global_events = _diff_user_global_for_shared_resource(
+            prev=prev_snapshot, next=next_snapshot
+        )
+        return response, False, user_global_events
+
+    response, did_replay, user_global_events = await run_in_threadpool(_core)
+    if did_replay:
+        return response
+
     # 共享账本:fan-out 给所有 LedgerMember(非只 owner)。否则 web/Owner 写
     # tx/budget/category/...,Editor 端 mobile 收不到 sync_change WS,要重启
     # app 才能看到新数据。
@@ -885,14 +1049,8 @@ async def _commit_write(
         },
     )
 
-    # §7 共享账本:对 user-global 实体(category/account/tag)再做一次
-    # shared_resource_change fan-out。Editor 的 /sync/pull 只返回自己
-    # scope=user 的变更,A 的 user-global 变更永远拉不到 — 必须靠这条
-    # WS 事件主动推,Editor 收到后更新本地 SharedLedger* 镜像表。
-    # mobile push 路径(sync/push.py:356)早已有此逻辑,web write 漏了。
-    user_global_events = _diff_user_global_for_shared_resource(
-        prev=prev_snapshot, next=next_snapshot
-    )
+    # Editor 的 /sync/pull 只返回自己 scope=user 的变更,Owner 的 user-global
+    # 变更永远拉不到 — 必须靠这条 WS 事件主动推。mobile push 路径早有此逻辑。
     if user_global_events:
         await _broadcast_shared_resource_events(
             request=request,
@@ -1160,6 +1318,7 @@ __all__ = [
     '_purge_expired_idempotency',
     '_load_idempotent_response',
     '_commit_write_fast_tx',
+    '_commit_create_tx_fast',
     '_projection_row_to_tx_dict',
     '_commit_write',
     '_prepare_write',

--- a/src/routers/write/transactions.py
+++ b/src/routers/write/transactions.py
@@ -47,7 +47,9 @@ async def create_tx(
     # web UI 下拉选项也从 snapshot 读,account_id / category_id / tag_ids 直接
     # 是 syncId,不再需要任何投影表。payload 直接传给 snapshot_mutator。
     mutate_payload = _payload_with_actor(payload, current_user, ledger=ledger)
-    return await _commit_write(
+    # issue #31 A1b:单笔新建走 fast path,不再全量 build snapshot(O(账本交易数)→O(1))。
+    # create 没有 diff 需求(新行即唯一变更),语义与 _commit_write 一致。
+    return await _commit_create_tx_fast(
         request=request,
         db=db,
         current_user=current_user,
@@ -57,7 +59,7 @@ async def create_tx(
         idempotency_key=idempotency_key,
         device_id=device_id,
         audit_action="web_tx_create",
-        mutate=lambda snapshot: create_transaction(snapshot, mutate_payload),
+        mutate_payload=mutate_payload,
     )
 
 

--- a/src/routers/write/transactions_batch.py
+++ b/src/routers/write/transactions_batch.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+from starlette.concurrency import run_in_threadpool
 
 from ... import snapshot_builder
 from ...concurrency import lock_ledger_for_materialize
@@ -173,162 +174,165 @@ async def create_tx_batch(
         # 也是同名 i18n,跨设备一致
         auto_tag_names.append(req.extra_tag_name)
 
-    # 3. lock + build snapshot
-    lock_ledger_for_materialize(db, ledger.id)
+    # 3. lock + build + mutate + commit 整段丢 threadpool(issue #31 A2),不阻塞
+    #    event loop(批量 build 是 O(账本交易数),正是导致"服务端短时无响应"的点);
+    #    广播在线程返回后做。_core 返回 (response, did_replay)。
+    def _core() -> tuple[BatchCreateTxResponse, bool]:
+        lock_ledger_for_materialize(db, ledger.id)
 
-    if get_settings().strict_base_change_id:
-        latest_any_change_id = snapshot_builder.latest_change_id(db, ledger.id)
-        if req.base_change_id != latest_any_change_id:
+        if get_settings().strict_base_change_id:
+            latest_any_change_id = snapshot_builder.latest_change_id(db, ledger.id)
+            if req.base_change_id != latest_any_change_id:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={
+                        "message": "Write conflict",
+                        "latest_change_id": latest_any_change_id,
+                    },
+                )
+
+        snapshot = snapshot_builder.build(db, ledger)
+        prev_snapshot = {**snapshot}
+        for _k in ("items", "accounts", "categories", "tags", "budgets"):
+            arr = snapshot.get(_k)
+            if isinstance(arr, list):
+                prev_snapshot[_k] = [dict(e) if isinstance(e, dict) else e for e in arr]
+
+        # 4. Ensure 所有用到的 tag 名字都在 snapshot.tags 里有实体,得到 name→sync_id map。
+        # 发现 snapshot.tags 里没这个名字 → 用 snapshot_mutator.create_tag 实际建实体,
+        # 后续 _emit_entity_diffs 会把它 emit 成 SyncChange + 写 UserTagProjection。
+        tag_name_to_sync_id: dict[str, str] = {}
+        existing_tags = snapshot.get("tags") or []
+        for t in existing_tags:
+            n = (t.get("name") or "").strip()
+            if n:
+                tag_name_to_sync_id.setdefault(n, str(t.get("syncId") or ""))
+
+        needed_names: set[str] = {n for n in auto_tag_names if n}
+        for _item in req.transactions:
+            if _item.tags:
+                needed_names.update(t for t in _item.tags if t)
+
+        for name in needed_names:
+            if name in tag_name_to_sync_id and tag_name_to_sync_id[name]:
+                continue
+            tag_payload = _payload_with_actor({"name": name}, current_user)
+            try:
+                snapshot, new_sync_id = create_tag(snapshot, tag_payload)
+                tag_name_to_sync_id[name] = new_sync_id
+            except ValueError:
+                # dup name → 防御性重扫 snapshot 找同名 sync_id。
+                for t in snapshot.get("tags") or []:
+                    if (t.get("name") or "").strip() == name:
+                        tag_name_to_sync_id[name] = str(t.get("syncId") or "")
+                        break
+
+        # 5. 循环 mutate snapshot,创建 N 笔
+        created_sync_ids: list[str] = []
+        try:
+            for i, item in enumerate(req.transactions):
+                tx_payload = _build_tx_payload(
+                    item=item,
+                    auto_tag_names=auto_tag_names,
+                    attachment_dict=attachment_dict,
+                    actor_user=current_user,
+                    tag_name_to_sync_id=tag_name_to_sync_id,
+                )
+                snapshot, sync_id = create_transaction(snapshot, tx_payload)
+                if sync_id:
+                    created_sync_ids.append(sync_id)
+        except (KeyError, ValueError, PermissionError) as exc:
+            logger.warning("tx.batch mutate failed at idx=%d: %s", i, exc)
             raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail={
-                    "message": "Write conflict",
-                    "latest_change_id": latest_any_change_id,
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"error_code": "BATCH_TX_INVALID", "message": str(exc), "failed_index": i},
+            )
+
+        # 6. emit 整批 diffs(_emit_entity_diffs 已经支持多 entity)
+        now = datetime.now(timezone.utc)
+        emitted_change_ids = _emit_entity_diffs(
+            db,
+            ledger=ledger,
+            current_user=current_user,
+            device_id=device_id,
+            prev=prev_snapshot,
+            next_snapshot=snapshot,
+            now=now,
+        )
+        new_change_id = max(emitted_change_ids) if emitted_change_ids else (
+            snapshot_builder.latest_change_id(db, ledger.id)
+        )
+
+        db.add(
+            AuditLog(
+                user_id=current_user.id,
+                ledger_id=ledger.id,
+                action="web_tx_batch_create",
+                metadata_json={
+                    "ledgerId": ledger.external_id,
+                    "baseChangeId": req.base_change_id,
+                    "newChangeId": new_change_id,
+                    "createdCount": len(created_sync_ids),
+                    "createdIds": created_sync_ids,
+                    "attachmentFileId": attachment_file_id,
+                    "autoTagNames": auto_tag_names,
                 },
             )
-
-    snapshot = snapshot_builder.build(db, ledger)
-    prev_snapshot = {**snapshot}
-    for _k in ("items", "accounts", "categories", "tags", "budgets"):
-        arr = snapshot.get(_k)
-        if isinstance(arr, list):
-            prev_snapshot[_k] = [dict(e) if isinstance(e, dict) else e for e in arr]
-
-    # 4. Ensure 所有用到的 tag 名字都在 snapshot.tags 里有实体,得到 name→sync_id map。
-    #
-    # 历史问题:_resolve_or_make_ai_tag_name 名字误导 — 它只 "resolve or pick a
-    # default *name*",**不创建实体**。extra_tag_name(图片/文字记账)更直接,
-    # 字符串 append 完就完事。导致 batch 创建的 tx 上看得到 chip,但 Tags 管理
-    # 页里这俩 tag 不存在 → tag_sync_ids_json 也填不上,Tags 详情查不到关联 tx。
-    #
-    # 这里改成跟 mobile 行为对齐:发现 snapshot.tags 里没这个名字 → 用
-    # snapshot_mutator.create_tag 实际建实体,后续 _emit_entity_diffs 会把它
-    # emit 成 SyncChange + 写 UserTagProjection。tx payload 直接引用 sync_id。
-    tag_name_to_sync_id: dict[str, str] = {}
-    existing_tags = snapshot.get("tags") or []
-    for t in existing_tags:
-        n = (t.get("name") or "").strip()
-        if n:
-            tag_name_to_sync_id.setdefault(n, str(t.get("syncId") or ""))
-
-    needed_names: set[str] = {n for n in auto_tag_names if n}
-    for _item in req.transactions:
-        if _item.tags:
-            needed_names.update(t for t in _item.tags if t)
-
-    for name in needed_names:
-        if name in tag_name_to_sync_id and tag_name_to_sync_id[name]:
-            continue
-        tag_payload = _payload_with_actor({"name": name}, current_user)
-        try:
-            snapshot, new_sync_id = create_tag(snapshot, tag_payload)
-            tag_name_to_sync_id[name] = new_sync_id
-        except ValueError:
-            # create_tag 内部 dup name 会 raise,理论上前面已 dedup 不会到这。
-            # 防御性重扫 snapshot 找同名 sync_id,实在没有就放弃(让 tx 带
-            # name-only 落库,跟历史行为兼容)。
-            for t in snapshot.get("tags") or []:
-                if (t.get("name") or "").strip() == name:
-                    tag_name_to_sync_id[name] = str(t.get("syncId") or "")
-                    break
-
-    # 5. 循环 mutate snapshot,创建 N 笔
-    created_sync_ids: list[str] = []
-    try:
-        for i, item in enumerate(req.transactions):
-            tx_payload = _build_tx_payload(
-                item=item,
-                auto_tag_names=auto_tag_names,
-                attachment_dict=attachment_dict,
-                actor_user=current_user,
-                tag_name_to_sync_id=tag_name_to_sync_id,
-            )
-            snapshot, sync_id = create_transaction(snapshot, tx_payload)
-            if sync_id:
-                created_sync_ids.append(sync_id)
-    except (KeyError, ValueError, PermissionError) as exc:
-        logger.warning("tx.batch mutate failed at idx=%d: %s", i, exc)
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail={"error_code": "BATCH_TX_INVALID", "message": str(exc), "failed_index": i},
         )
 
-    # 5. emit 整批 diffs(_emit_entity_diffs 已经支持多 entity)
-    now = datetime.now(timezone.utc)
-    emitted_change_ids = _emit_entity_diffs(
-        db,
-        ledger=ledger,
-        current_user=current_user,
-        device_id=device_id,
-        prev=prev_snapshot,
-        next_snapshot=snapshot,
-        now=now,
-    )
-    new_change_id = max(emitted_change_ids) if emitted_change_ids else (
-        snapshot_builder.latest_change_id(db, ledger.id)
-    )
-
-    db.add(
-        AuditLog(
-            user_id=current_user.id,
-            ledger_id=ledger.id,
-            action="web_tx_batch_create",
-            metadata_json={
-                "ledgerId": ledger.external_id,
-                "baseChangeId": req.base_change_id,
-                "newChangeId": new_change_id,
-                "createdCount": len(created_sync_ids),
-                "createdIds": created_sync_ids,
-                "attachmentFileId": attachment_file_id,
-                "autoTagNames": auto_tag_names,
-            },
-        )
-    )
-
-    response = BatchCreateTxResponse(
-        ledger_id=ledger.external_id,
-        base_change_id=req.base_change_id,
-        new_change_id=new_change_id,
-        server_timestamp=now,
-        created_sync_ids=created_sync_ids,
-        attachment_id=attachment_file_id,
-    )
-
-    request_hash = _hash_request(request.method, request.url.path, payload_for_ide)
-    if idempotency_key:
-        db.add(
-            SyncPushIdempotency(
-                user_id=current_user.id,
-                device_id=device_id,
-                idempotency_key=idempotency_key,
-                request_hash=request_hash,
-                response_json=response.model_dump(mode="json"),
-                created_at=now,
-                expires_at=now + timedelta(hours=24),
-            )
+        response = BatchCreateTxResponse(
+            ledger_id=ledger.external_id,
+            base_change_id=req.base_change_id,
+            new_change_id=new_change_id,
+            server_timestamp=now,
+            created_sync_ids=created_sync_ids,
+            attachment_id=attachment_file_id,
         )
 
-    try:
-        db.commit()
-    except IntegrityError:
-        db.rollback()
+        request_hash = _hash_request(request.method, request.url.path, payload_for_ide)
         if idempotency_key:
-            replay = _load_idempotent_response(
-                db,
-                user_id=current_user.id,
-                device_id=device_id,
-                idempotency_key=idempotency_key,
-                request_hash=request_hash,
+            db.add(
+                SyncPushIdempotency(
+                    user_id=current_user.id,
+                    device_id=device_id,
+                    idempotency_key=idempotency_key,
+                    request_hash=request_hash,
+                    response_json=response.model_dump(mode="json"),
+                    created_at=now,
+                    expires_at=now + timedelta(hours=24),
+                )
             )
-            if replay is not None:
-                return BatchCreateTxResponse(**replay.model_dump()) if hasattr(replay, "model_dump") else replay  # type: ignore[return-value]
-        raise
 
-    logger.info(
-        "tx.batch_create ledger=%s count=%d change_id=%d device=%s user=%s tags=%s attach=%s",
-        ledger.external_id, len(created_sync_ids), new_change_id, device_id,
-        current_user.id, auto_tag_names, attachment_file_id,
-    )
+        try:
+            db.commit()
+        except IntegrityError:
+            db.rollback()
+            if idempotency_key:
+                replay = _load_idempotent_response(
+                    db,
+                    user_id=current_user.id,
+                    device_id=device_id,
+                    idempotency_key=idempotency_key,
+                    request_hash=request_hash,
+                )
+                if replay is not None:
+                    replay_resp = (
+                        BatchCreateTxResponse(**replay.model_dump())
+                        if hasattr(replay, "model_dump") else replay
+                    )
+                    return replay_resp, True  # type: ignore[return-value]
+            raise
+
+        logger.info(
+            "tx.batch_create ledger=%s count=%d change_id=%d device=%s user=%s tags=%s attach=%s",
+            ledger.external_id, len(created_sync_ids), new_change_id, device_id,
+            current_user.id, auto_tag_names, attachment_file_id,
+        )
+        return response, False
+
+    response, did_replay = await run_in_threadpool(_core)
+    if did_replay:
+        return response
 
     # 共享账本:fan-out 给所有 LedgerMember,Editor 端 mobile 实时收到。
     from ...websocket_manager import broadcast_to_ledger
@@ -339,8 +343,8 @@ async def create_tx_batch(
         payload={
             "type": "sync_change",
             "ledgerId": ledger.external_id,
-            "serverCursor": new_change_id,
-            "serverTimestamp": now.isoformat(),
+            "serverCursor": response.new_change_id,
+            "serverTimestamp": response.server_timestamp.isoformat(),
         },
     )
     return response

--- a/tests/test_issue31_phantom_ledger.py
+++ b/tests/test_issue31_phantom_ledger.py
@@ -1,0 +1,267 @@
+"""issue #31 回归测试 —— 幽灵/软删账本 + MCP 写入不瞎猜账本。
+
+覆盖修复:
+  - B1: MCP `_resolve_ledger`/`list_ledgers`/`get_active_ledger` 排除软删账本
+  - B2: web /write/* 写软删账本 → 404,且不"复活"其 projection
+  - B3: /workspace/* 跨账本读排除软删账本(即便其 projection 残留行)
+  - B5: MCP 写工具在多账本未指定时拒绝瞎猜,返回候选
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.database import Base, get_db
+from src.main import app
+from src.mcp.tools import read_tools, write_tools
+from src.models import Ledger, ReadTxProjection, SyncChange, User
+
+
+def _make_client_and_engine(monkeypatch):
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TS = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    def override():
+        db = TS()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override
+    # read_tools / write_tools 直接 `with SessionLocal() as db:`,不走 dep tree。
+    monkeypatch.setattr(read_tools, "SessionLocal", TS)
+    monkeypatch.setattr(write_tools, "SessionLocal", TS)
+    return TestClient(app), TS
+
+
+def _register(client: TestClient, email: str) -> dict:
+    res = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "password": "123456",
+            "client_type": "web",
+            "device_name": "pytest-web",
+            "platform": "web",
+        },
+    )
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _make_ledger(client: TestClient, token: str, name: str) -> str:
+    res = client.post(
+        "/api/v1/write/ledgers",
+        json={"ledger_name": name, "currency": "CNY"},
+        headers={"Authorization": f"Bearer {token}", "X-Device-ID": "d-web"},
+    )
+    assert res.status_code == 200, res.text
+    return res.json()["entity_id"]
+
+
+def _delete_ledger(client: TestClient, token: str, ext_id: str) -> None:
+    res = client.delete(
+        f"/api/v1/write/ledgers/{ext_id}",
+        headers={"Authorization": f"Bearer {token}", "X-Device-ID": "d-web"},
+    )
+    assert res.status_code == 200, res.text
+
+
+def _add_tx(client: TestClient, token: str, ledger_ext: str, amount: float = 10.0):
+    return client.post(
+        f"/api/v1/write/ledgers/{ledger_ext}/transactions",
+        json={
+            "base_change_id": 0,
+            "tx_type": "expense",
+            "amount": amount,
+            "happened_at": datetime.now(timezone.utc).isoformat(),
+        },
+        headers={"Authorization": f"Bearer {token}", "X-Device-ID": "d-web"},
+    )
+
+
+def _fetch_user(TS, email: str) -> User:
+    with TS() as db:
+        u = db.scalar(select(User).where(User.email == email))
+        assert u is not None
+        db.expunge(u)
+        return u
+
+
+# --------------------------------------------------------------------------
+# B1 — MCP 解析/列举排除软删账本
+# --------------------------------------------------------------------------
+
+
+def test_b1_mcp_read_excludes_soft_deleted_ledger(monkeypatch) -> None:
+    client, TS = _make_client_and_engine(monkeypatch)
+    try:
+        u = _register(client, "b1@example.com")
+        token = u["access_token"]
+        first = _make_ledger(client, token, "First")   # 最早创建
+        second = _make_ledger(client, token, "Second")
+        _delete_ledger(client, token, first)            # 软删最早那个(模拟幽灵默认账本)
+
+        user = _fetch_user(TS, "b1@example.com")
+
+        # list_ledgers 不再返回软删的 First
+        names = {lg["name"] for lg in read_tools.list_ledgers(user)}
+        assert names == {"Second"}, names
+
+        # get_active_ledger 回退到 Second(此前会顽固选中最早的 First)
+        active = read_tools.get_active_ledger(user)
+        assert active is not None and active["name"] == "Second"
+
+        # 显式传软删账本 id → None;传 live 账本 → 命中
+        with TS() as db:
+            assert read_tools._resolve_ledger(db, user.id, first) is None
+            assert read_tools._resolve_ledger(db, user.id, second) is not None
+    finally:
+        app.dependency_overrides.clear()
+
+
+# --------------------------------------------------------------------------
+# B2 — 写软删账本被拒,且不复活 projection
+# --------------------------------------------------------------------------
+
+
+def test_b2_write_to_soft_deleted_ledger_404_no_resurrection(monkeypatch) -> None:
+    client, TS = _make_client_and_engine(monkeypatch)
+    try:
+        u = _register(client, "b2@example.com")
+        token = u["access_token"]
+        led = _make_ledger(client, token, "Solo")
+        _delete_ledger(client, token, led)
+
+        # 往软删账本写一笔 → 404(此前会成功并"复活"projection)
+        res = _add_tx(client, token, led)
+        assert res.status_code == 404, res.text
+
+        # 确认 projection 没有被复活出任何行
+        with TS() as db:
+            led_row = db.scalar(select(Ledger).where(Ledger.external_id == led))
+            assert led_row is not None  # 软删保留壳行
+            cnt = db.scalar(
+                select(func.count())
+                .select_from(ReadTxProjection)
+                .where(ReadTxProjection.ledger_id == led_row.id)
+            )
+            assert cnt == 0
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_b2_live_ledger_write_still_works(monkeypatch) -> None:
+    """回归:B2 不能误伤正常账本的写入。"""
+    client, TS = _make_client_and_engine(monkeypatch)
+    try:
+        u = _register(client, "b2ok@example.com")
+        token = u["access_token"]
+        led = _make_ledger(client, token, "Live")
+        res = _add_tx(client, token, led, amount=12.5)
+        assert res.status_code == 200, res.text
+    finally:
+        app.dependency_overrides.clear()
+
+
+# --------------------------------------------------------------------------
+# B3 — 跨账本/tag 读排除软删账本(即便 projection 残留复活行)
+# --------------------------------------------------------------------------
+
+
+def test_b3_workspace_excludes_soft_deleted_ledger_txns(monkeypatch) -> None:
+    client, TS = _make_client_and_engine(monkeypatch)
+    try:
+        u = _register(client, "b3@example.com")
+        token = u["access_token"]
+        alive = _make_ledger(client, token, "Alive")
+        ghost = _make_ledger(client, token, "Ghost")
+        assert _add_tx(client, token, alive, amount=11.0).status_code == 200
+        assert _add_tx(client, token, ghost, amount=22.0).status_code == 200
+
+        # 直接插一条 Ghost 的 delete tombstone,模拟"复活/孤儿"存量坏数据:
+        # tombstone 在(账本被判软删),但 projection 行仍残留 —— 不走
+        # delete_ledger(它会 truncate projection,无法构造这个状态)。
+        with TS() as db:
+            ghost_row = db.scalar(select(Ledger).where(Ledger.external_id == ghost))
+            db.add(
+                SyncChange(
+                    user_id=ghost_row.user_id,
+                    ledger_id=ghost_row.id,
+                    entity_type="ledger_snapshot",
+                    entity_sync_id=ghost,
+                    action="delete",
+                    payload_json={},
+                    updated_at=datetime.now(timezone.utc),
+                    updated_by_device_id="pytest",
+                    updated_by_user_id=ghost_row.user_id,
+                )
+            )
+            db.commit()
+
+        # /workspace/transactions 只应返回 Alive 的交易,Ghost 的被过滤
+        res = client.get(
+            "/api/v1/read/workspace/transactions",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert res.status_code == 200, res.text
+        items = res.json()["items"]
+        assert {it["ledger_name"] for it in items} == {"Alive"}, items
+        assert 22.0 not in {it["amount"] for it in items}
+    finally:
+        app.dependency_overrides.clear()
+
+
+# --------------------------------------------------------------------------
+# B5 — MCP 写工具多账本不瞎猜
+# --------------------------------------------------------------------------
+
+
+def test_b5_resolve_write_ledger_refuses_to_guess(monkeypatch) -> None:
+    client, TS = _make_client_and_engine(monkeypatch)
+    try:
+        u = _register(client, "b5@example.com")
+        token = u["access_token"]
+        user = _fetch_user(TS, "b5@example.com")
+
+        # 0 账本 → no_ledger
+        with TS() as db:
+            led, status = write_tools._resolve_write_ledger(db, user, None)
+            assert led is None and status["status"] == "no_ledger"
+
+        # 1 个 live 账本 → 自动选它
+        first = _make_ledger(client, token, "Only")
+        with TS() as db:
+            led, status = write_tools._resolve_write_ledger(db, user, None)
+            assert status is None and led is not None and led.external_id == first
+
+        # 2 个 live 账本 + 未指定 → 拒绝瞎猜,返回候选
+        second = _make_ledger(client, token, "Second")
+        with TS() as db:
+            led, status = write_tools._resolve_write_ledger(db, user, None)
+            assert led is None
+            assert status["status"] == "ledger_required"
+            assert {c["id"] for c in status["candidates"]} == {first, second}
+
+        # 显式指定但该账本已软删 → ledger_not_found
+        _delete_ledger(client, token, first)
+        with TS() as db:
+            led, status = write_tools._resolve_write_ledger(db, user, first)
+            assert led is None and status["status"] == "ledger_not_found"
+
+        # 显式指定 live 账本 → 成功
+        with TS() as db:
+            led, status = write_tools._resolve_write_ledger(db, user, second)
+            assert status is None and led is not None and led.external_id == second
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_issue31_write_perf.py
+++ b/tests/test_issue31_write_perf.py
@@ -1,0 +1,248 @@
+"""issue #31 A1b / A3 回归测试 —— 单笔 create fast-path + 批量 MCP 写工具。
+
+  - A1b: POST /write/ledgers/{id}/transactions 走 _commit_create_tx_fast,
+         产出的 tx 可读、sync_change 可 pull(语义与旧的全量 build 路径一致)。
+  - A3:  write_tools.create_transactions 批量工具:分块走 /transactions/batch、
+         注入 MCP 标签、多账本拒绝瞎猜、未知分类清晰报错。
+  (A2 的 threadpool 化由全量 write 测试覆盖 —— 所有 POST/PATCH/DELETE 现在都
+   经过 run_in_threadpool。)
+"""
+from __future__ import annotations
+
+import asyncio
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src import _mcp_internal_client
+from src.database import Base, get_db
+from src.main import app
+from src.mcp.tools import read_tools, write_tools
+from src.models import User
+
+
+def _make_client_and_engine(monkeypatch):
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TS = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    def override():
+        db = TS()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override
+    monkeypatch.setattr(read_tools, "SessionLocal", TS)
+    monkeypatch.setattr(write_tools, "SessionLocal", TS)
+    return TestClient(app), TS
+
+
+def _register(client: TestClient, email: str) -> dict:
+    res = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "password": "123456",
+            "client_type": "web",
+            "device_name": "pytest-web",
+            "platform": "web",
+        },
+    )
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _make_ledger(client: TestClient, token: str, name: str) -> str:
+    res = client.post(
+        "/api/v1/write/ledgers",
+        json={"ledger_name": name, "currency": "CNY"},
+        headers={"Authorization": f"Bearer {token}", "X-Device-ID": "d-web"},
+    )
+    assert res.status_code == 200, res.text
+    return res.json()["entity_id"]
+
+
+def _fetch_user(TS, email: str) -> User:
+    with TS() as db:
+        u = db.scalar(select(User).where(User.email == email))
+        assert u is not None
+        db.expunge(u)
+        return u
+
+
+def _run_async(coro):
+    """驱动 async MCP write tool。internal ASGI client 是进程级单例 —— 每次重置,
+    绑到本次 asyncio.run 的 loop;跑完再清掉,别泄漏给后续测试。"""
+    _mcp_internal_client._client = None
+    try:
+        return asyncio.run(coro)
+    finally:
+        _mcp_internal_client._client = None
+
+
+# --------------------------------------------------------------------------
+# A1b — 单笔 create fast-path
+# --------------------------------------------------------------------------
+
+
+def test_a1b_create_fast_path_roundtrip(monkeypatch) -> None:
+    client, _TS = _make_client_and_engine(monkeypatch)
+    try:
+        u = _register(client, "a1b@example.com")
+        token = u["access_token"]
+        led = _make_ledger(client, token, "L")
+        hdr = {"Authorization": f"Bearer {token}", "X-Device-ID": "d-web"}
+
+        res = client.post(
+            f"/api/v1/write/ledgers/{led}/transactions",
+            json={
+                "base_change_id": 0,
+                "tx_type": "expense",
+                "amount": 12.5,
+                "happened_at": "2026-05-01T00:00:00+00:00",
+                "note": "coffee",
+            },
+            headers=hdr,
+        )
+        assert res.status_code == 200, res.text
+        sync_id = res.json()["entity_id"]
+        assert sync_id
+
+        # 读回:fast-path 写的 tx 字段正确
+        r2 = client.get(f"/api/v1/read/ledgers/{led}/transactions", headers=hdr)
+        assert r2.status_code == 200, r2.text
+        rows = [it for it in r2.json() if it["id"] == sync_id]
+        assert len(rows) == 1, r2.json()
+        assert rows[0]["amount"] == 12.5
+        assert rows[0]["note"] == "coffee"
+        assert rows[0]["tx_type"] == "expense"
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_a1b_create_fast_path_emits_pullable_change(monkeypatch) -> None:
+    client, _TS = _make_client_and_engine(monkeypatch)
+    try:
+        u = _register(client, "a1bpull@example.com")
+        token, device = u["access_token"], u["device_id"]
+        led = _make_ledger(client, token, "L")
+        hdr = {"Authorization": f"Bearer {token}", "X-Device-ID": "other-device"}
+
+        res = client.post(
+            f"/api/v1/write/ledgers/{led}/transactions",
+            json={"base_change_id": 0, "tx_type": "income", "amount": 9,
+                  "happened_at": "2026-05-02T00:00:00+00:00"},
+            headers=hdr,
+        )
+        assert res.status_code == 200, res.text
+        sync_id = res.json()["entity_id"]
+
+        # fast-path 必须 emit 一条可增量 pull 的 transaction upsert change
+        r = client.get("/api/v1/sync/pull?since=0&limit=500",
+                       headers={"Authorization": f"Bearer {token}", "X-Device-ID": device})
+        assert r.status_code == 200, r.text
+        tx_changes = [
+            c for c in r.json()["changes"]
+            if c.get("entity_type") == "transaction"
+            and c.get("entity_sync_id") == sync_id
+            and c.get("action") == "upsert"
+        ]
+        assert len(tx_changes) == 1, r.json()
+    finally:
+        app.dependency_overrides.clear()
+
+
+# --------------------------------------------------------------------------
+# A3 — 批量 MCP 写工具
+# --------------------------------------------------------------------------
+
+
+def test_a3_batch_endpoint_one_commit(monkeypatch) -> None:
+    """A3 的落地端点 /transactions/batch:50 笔一次 commit + A2 threadpool 化后仍
+    正确。(create_transactions 这个 MCP 包装器对它的 self-call 走 app-scope token,
+    而测试套件 conftest 把 ALLOW_APP_RW_SCOPES 设为 false,self-call 必 403 —— 跟
+    test_mcp_tools 只测 read 工具同因;故这里直接用 web token 测端点本体。)"""
+    client, _TS = _make_client_and_engine(monkeypatch)
+    try:
+        u = _register(client, "batch@example.com")
+        token = u["access_token"]
+        led = _make_ledger(client, token, "B")
+        hdr = {"Authorization": f"Bearer {token}", "X-Device-ID": "d-web"}
+
+        txns = [
+            {"tx_type": "expense", "amount": 1.0 + i,
+             "happened_at": "2026-05-01T00:00:00+00:00", "tags": ["MCP"]}
+            for i in range(50)
+        ]
+        res = client.post(
+            f"/api/v1/write/ledgers/{led}/transactions/batch",
+            json={"base_change_id": 0, "transactions": txns, "auto_ai_tag": False},
+            headers=hdr,
+        )
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert len(body["created_sync_ids"]) == 50
+        assert body["new_change_id"] > 0  # 单次 commit 的 change_id
+
+        # 全部落库 + MCP tag 实体建出来了
+        r = client.get(f"/api/v1/read/ledgers/{led}/transactions?limit=200", headers=hdr)
+        assert r.status_code == 200, r.text
+        assert len(r.json()) == 50
+        tags = client.get(f"/api/v1/read/ledgers/{led}/tags", headers=hdr).json()
+        assert any(t["name"] == "MCP" for t in tags), tags
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_a3_bulk_refuses_multi_ledger_without_id(monkeypatch) -> None:
+    client, TS = _make_client_and_engine(monkeypatch)
+    try:
+        u = _register(client, "a3multi@example.com")
+        token = u["access_token"]
+        _make_ledger(client, token, "One")
+        _make_ledger(client, token, "Two")
+        user = _fetch_user(TS, "a3multi@example.com")
+
+        result = _run_async(
+            write_tools.create_transactions(
+                user,
+                transactions=[{"amount": 5, "tx_type": "expense", "happened_at": "2026-05-01"}],
+                ledger_id=None,
+            )
+        )
+        # B5:多账本不指定 → 拒绝瞎猜,返回候选(不写入)
+        assert result["status"] == "ledger_required", result
+        assert len(result["candidates"]) == 2
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_a3_bulk_unknown_category_errors(monkeypatch) -> None:
+    import pytest
+
+    client, TS = _make_client_and_engine(monkeypatch)
+    try:
+        u = _register(client, "a3cat@example.com")
+        token = u["access_token"]
+        led = _make_ledger(client, token, "L")
+        user = _fetch_user(TS, "a3cat@example.com")
+
+        with pytest.raises(ValueError, match="Unknown categories"):
+            _run_async(
+                write_tools.create_transactions(
+                    user,
+                    transactions=[{"amount": 5, "category": "NoSuchCat",
+                                   "happened_at": "2026-05-01"}],
+                    ledger_id=led,
+                )
+            )
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
Closes #31

issue #31 报告的其实是**两个独立 bug**,本 PR 一并修复。

## 数据正确性(B)
- **B1** MCP `_resolve_ledger` / `list_ledgers` / `get_active_ledger` 统一过滤软删账本,与 web/mobile 账本可见性口径对齐 —— 不再解析 / 列出"幽灵默认账本"。
- **B2** 写路径 `_load_ledger_for_write` 拒绝写入软删账本(404),防止一次写入就"复活"它的 projection(产生 web 看不见、tag 里却查得到、又删不掉的幽灵交易)。
- **B3** workspace 跨账本 / tag / 统计 / CSV 读排除软删账本(此前不过滤,正是"tag 看得到、账本列表没有"的来源)。
- **B5** MCP 写工具多账本未指定时**不瞎猜**,返回候选逼显式 `ledger_id`。

## 性能 / 可用性(A)
- **A3** 新增 `create_transactions` 批量 MCP 工具,分块 ≤50 走现有 `/transactions/batch`(一次 commit + 一次广播),批量导入从 O(N²) builds 降到 ~O(N)。
- **A1b** 单笔 create 走 fast-path,跳过全量 `snapshot_builder.build`,O(账本交易数)→ O(1);与旧路径产出的 SyncChange / projection 行逐字等价。
- **A2** 4 个 commit 函数(create-fast / fast-tx / `_commit_write` / batch)同步 DB 段移入 `run_in_threadpool`,不阻塞 event loop(修"批量写时服务端短时无响应")。端点签名不变,blast radius 限定在这 4 个函数内。

## 测试
- 新增 `tests/test_issue31_phantom_ledger.py`(B1/B2/B3/B5)+ `tests/test_issue31_write_perf.py`(A1b/A3/batch),共 10 条。
- 全量 `pytest tests/` → **315 passed**。
- 暂缓:B4(幽灵默认账本存量数据清理 + mobile 侧 fresh-install 默认账本不无脑上云)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **新功能**
  * 新增批量导入交易功能，支持一次性提交多笔交易
  * 改进多账本场景下的账本选择体验，避免自动猜测，提供候选列表供用户选择

* **Bug修复**
  * 修复软删除账本在读取、写入和MCP工具中的过滤问题，防止意外数据残留
  * 完善账本删除后的数据隔离，确保已删除账本无法进行新的写入操作

<!-- end of auto-generated comment: release notes by coderabbit.ai -->