### PR TITLE
fix(web): 金额紧凑单位跟随界面语言(英文 k/M、繁体「萬」)

### DIFF
--- a/frontend/apps/web/src/components/dashboard/MonthlyTrendBars.tsx
+++ b/frontend/apps/web/src/components/dashboard/MonthlyTrendBars.tsx
@@ -10,7 +10,9 @@ import {
   XAxis,
   YAxis
 } from 'recharts'
-import { Card, CardContent, CardHeader, CardTitle, useT } from '@beecount/ui'
+import { Card, CardContent, CardHeader, CardTitle, useLocale, useT } from '@beecount/ui'
+
+import { formatCompactTick } from '../../i18n/format'
 
 interface SeriesItem {
   bucket: string
@@ -37,6 +39,8 @@ const TREND_WINDOW = 12
  */
 export function MonthlyTrendBars({ data }: Props) {
   const t = useT()
+  const { locale } = useLocale()
+  const chinese = locale.startsWith('zh')
 
   const slice = useMemo(() => {
     const tail = data.slice(-TREND_WINDOW)
@@ -81,7 +85,9 @@ export function MonthlyTrendBars({ data }: Props) {
                 <YAxis
                   tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 11 }}
                   stroke="hsl(var(--border))"
-                  tickFormatter={(v) => (Math.abs(v) >= 10000 ? `${(v / 10000).toFixed(1)}${t('home.trendBars.10kUnit')}` : String(v))}
+                  tickFormatter={(v) =>
+                    formatCompactTick(v, { chinese, wanUnit: t('common.unit.10k') })
+                  }
                 />
                 <Tooltip
                   contentStyle={{

--- a/frontend/apps/web/src/components/dialogs/CategoryDetailDialog.tsx
+++ b/frontend/apps/web/src/components/dialogs/CategoryDetailDialog.tsx
@@ -11,11 +11,13 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  useLocale,
   useT,
 } from '@beecount/ui'
 import { Amount, CategoryIcon, TransactionList } from '@beecount/web-features'
 import { ArrowRight, Edit3, TrendingDown, TrendingUp } from 'lucide-react'
 
+import { formatCompactTick } from '../../i18n/format'
 import type { DetailScope } from '../../lib/txDialogEvents'
 import { DetailScopeToggle } from './DetailScopeToggle'
 import {
@@ -111,6 +113,8 @@ export function CategoryDetailDialog({
   onJumpToTransactions,
 }: Props) {
   const t = useT()
+  const { locale } = useLocale()
+  const chinese = locale.startsWith('zh')
 
   const tagColorByName = useMemo(() => {
     const map = new Map<string, string | null>()
@@ -225,6 +229,7 @@ export function CategoryDetailDialog({
                 kind={category.kind}
                 currency={currency}
                 t={t}
+                chinese={chinese}
               />
 
               <div className="grid gap-4 border-b border-border/60 px-6 py-4 sm:grid-cols-2">
@@ -383,11 +388,13 @@ function TrendBars({
   kind,
   currency,
   t,
+  chinese,
 }: {
   monthly: { bucket: string; amount: number; count: number }[]
   kind: WorkspaceCategory['kind']
   currency: string
   t: (k: string) => string
+  chinese: boolean
 }) {
   // 取最近 12 个月。如果不足 12 期,补空格保证轴长度一致,视觉上能看出"才记账几个月"。
   const slice = useMemo(() => fillTrailingMonths(monthly, 12), [monthly])
@@ -452,9 +459,7 @@ function TrendBars({
                 tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 10 }}
                 stroke="hsl(var(--border))"
                 tickFormatter={(v: number) =>
-                  Math.abs(v) >= 10000
-                    ? `${(v / 10000).toFixed(1)}${t('home.trendBars.10kUnit')}`
-                    : String(v)
+                  formatCompactTick(v, { chinese, wanUnit: t('common.unit.10k') })
                 }
                 width={40}
               />

--- a/frontend/apps/web/src/i18n.test.ts
+++ b/frontend/apps/web/src/i18n.test.ts
@@ -6,13 +6,14 @@ import {
   persistLocale
 } from '@beecount/ui'
 import { ApiError } from '@beecount/api-client'
+import { formatBalanceCompact } from '@beecount/web-features'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import en from './i18n/en'
 import zhCN from './i18n/zh-CN'
 import zhTW from './i18n/zh-TW'
 import { localizeError } from './i18n/errors'
-import { formatAmountCny, formatIsoDateTime } from './i18n/format'
+import { formatAmountCny, formatCompactTick, formatIsoDateTime } from './i18n/format'
 
 describe('i18n locale runtime', () => {
   afterEach(() => {
@@ -73,6 +74,43 @@ describe('i18n error mapping and formatting', () => {
   it('formats amount and datetime in fixed mode', () => {
     expect(formatAmountCny(12.5)).toBe('CNY 12.50')
     expect(formatIsoDateTime('2026-02-25T10:20:30Z')).toBe('2026-02-25 10:20:30')
+  })
+})
+
+/**
+ * 紧凑金额单位跟随 UI 语言:中文「万 / 萬」、英文「k / M」。
+ * 锁住 bug —— 英文界面下的 CNY 金额曾仍显示「247.25万」,应为「2.47M」。
+ */
+describe('compact amount locale unit', () => {
+  it('formatBalanceCompact uses 万 for chinese', () => {
+    expect(formatBalanceCompact(50000, 'CNY', { chinese: true })).toBe('¥5万')
+    expect(formatBalanceCompact(2472500, 'CNY', { chinese: true })).toBe('¥247.25万')
+    // < 1 万保留两位
+    expect(formatBalanceCompact(980, 'CNY', { chinese: true })).toBe('¥980.00')
+  })
+
+  it('formatBalanceCompact honors traditional 萬 via wanUnit', () => {
+    expect(formatBalanceCompact(2472500, 'CNY', { chinese: true, wanUnit: '萬' })).toBe('¥247.25萬')
+    expect(formatBalanceCompact(50000, 'CNY', { chinese: true, wanUnit: '萬' })).toBe('¥5萬')
+  })
+
+  it('formatBalanceCompact uses k / M for english (even CNY)', () => {
+    expect(formatBalanceCompact(50000, 'CNY', { chinese: false })).toBe('¥50k')
+    expect(formatBalanceCompact(2472500, 'CNY', { chinese: false })).toBe('¥2.47M')
+    expect(formatBalanceCompact(980, 'CNY', { chinese: false })).toBe('¥980.00')
+    // currencyCode 传 null 不带符号
+    expect(formatBalanceCompact(50000, null, { chinese: false })).toBe('50k')
+  })
+
+  it('formatCompactTick abbreviates by locale, keeps small values integer', () => {
+    // 英文:÷1000 标 k(修复旧的「÷10000 却标 k」=> 10 倍偏小 bug)
+    expect(formatCompactTick(50000, { chinese: false })).toBe('50.0k')
+    expect(formatCompactTick(2_000_000, { chinese: false })).toBe('2.0M')
+    expect(formatCompactTick(500, { chinese: false })).toBe('500')
+    // 中文:÷10000 标万/萬(单位由调用方传入)
+    expect(formatCompactTick(50000, { chinese: true, wanUnit: '万' })).toBe('5.0万')
+    expect(formatCompactTick(50000, { chinese: true, wanUnit: '萬' })).toBe('5.0萬')
+    expect(formatCompactTick(5000, { chinese: true, wanUnit: '万' })).toBe('5000')
   })
 })
 

--- a/frontend/apps/web/src/i18n/en.ts
+++ b/frontend/apps/web/src/i18n/en.ts
@@ -719,7 +719,7 @@ const en = {
   'home.trendBars.income': 'Income',
   'home.trendBars.expense': 'Expense',
   'home.trendBars.balance': 'Net',
-  'home.trendBars.10kUnit': 'k',
+  'common.unit.10k': 'k',
 
   'home.assetComp.title': 'Asset composition',
   'home.assetComp.empty': 'No accounts yet',

--- a/frontend/apps/web/src/i18n/format.ts
+++ b/frontend/apps/web/src/i18n/format.ts
@@ -1,1 +1,1 @@
-export { formatAmountCny, formatIsoDateTime } from '@beecount/web-features'
+export { formatAmountCny, formatCompactTick, formatIsoDateTime } from '@beecount/web-features'

--- a/frontend/apps/web/src/i18n/zh-CN.ts
+++ b/frontend/apps/web/src/i18n/zh-CN.ts
@@ -272,7 +272,7 @@ const zhCN = {
   'home.trendBars.income': '收入',
   'home.trendBars.expense': '支出',
   'home.trendBars.balance': '净额',
-  'home.trendBars.10kUnit': '万',
+  'common.unit.10k': '万',
 
   // AssetCompositionDonut
   'home.assetComp.title': '资产构成',

--- a/frontend/apps/web/src/i18n/zh-TW.ts
+++ b/frontend/apps/web/src/i18n/zh-TW.ts
@@ -718,7 +718,7 @@ const zhTW = {
   'home.trendBars.income': '收入',
   'home.trendBars.expense': '支出',
   'home.trendBars.balance': '淨額',
-  'home.trendBars.10kUnit': '萬',
+  'common.unit.10k': '萬',
 
   'home.assetComp.title': '資產組成',
   'home.assetComp.empty': '暫無帳戶資料',

--- a/frontend/apps/web/src/pages/sections/CalendarPage.tsx
+++ b/frontend/apps/web/src/pages/sections/CalendarPage.tsx
@@ -8,7 +8,7 @@ import {
   type WorkspaceAnalyticsSeriesItem,
   type WorkspaceTransaction,
 } from '@beecount/api-client'
-import { Button, Card, CardContent, useT } from '@beecount/ui'
+import { Button, Card, CardContent, useLocale, useT } from '@beecount/ui'
 import { ChevronLeft, ChevronRight, Info, Plus, Sparkles } from 'lucide-react'
 
 import { useAuth } from '../../context/AuthContext'
@@ -564,6 +564,8 @@ function DayCell({
   monthMaxAbsNet,
   onSelect,
 }: DayCellProps) {
+  const { locale } = useLocale()
+  const chinese = locale.startsWith('zh')
   const dayNum = Number(dateKey.slice(8))
 
   // 周末判断:0=周日 / 6=周六 → 给一个非常微弱的灰底,跟工作日区分但不抢戏
@@ -653,7 +655,7 @@ function DayCell({
             }
           >
             {bucket.net >= 0 ? '+' : ''}
-            {compactNum(bucket.net)}
+            {compactNum(bucket.net, chinese)}
           </span>
         </div>
       )}
@@ -661,12 +663,17 @@ function DayCell({
   )
 }
 
-// 单元格内的紧凑数字格式化:千 = k,万 = w(中文习惯)
-function compactNum(value: number): string {
+// 单元格内的紧凑数字格式化。中文习惯:千 = k,万 = w;英文区:千 = k,百万 = M
+// (不出现「w/万」)。chinese 由调用方按 UI 语言传入。
+function compactNum(value: number, chinese: boolean): string {
   const abs = Math.abs(value)
   if (abs < 1000) return value.toFixed(0)
-  if (abs < 10000) return `${(value / 1000).toFixed(1)}k`
-  return `${(value / 10000).toFixed(1)}w`
+  if (chinese) {
+    if (abs < 10000) return `${(value / 1000).toFixed(1)}k`
+    return `${(value / 10000).toFixed(1)}w`
+  }
+  if (abs >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  return `${(value / 1000).toFixed(1)}k`
 }
 
 // ============================================================================

--- a/frontend/packages/web-features/src/components/Amount.tsx
+++ b/frontend/packages/web-features/src/components/Amount.tsx
@@ -1,17 +1,22 @@
+import { useLocale, useT } from '@beecount/ui'
+
 import { formatBalanceCompact } from '../format'
 
 /**
  * 通用金额展示组件。全站所有"金额"类文案都走这里，方便统一改：
  *
  * - 默认使用紧凑格式（`formatBalanceCompact`），对齐 mobile 的"X.X万 / X.Xk / X.XM"规则。
+ * - 紧凑单位跟随 **UI 语言**而非币种:中文(zh-CN / zh-TW)用「万 / 萬」,英文用
+ *   "k / M" —— 这样英文界面下哪怕是 CNY 账本也不会再蹦出「247.25万」这种不符合
+ *   英文区阅读习惯的写法(见 #英文金额统计 issue)。
  * - `compact={false}` 时回退到千分号两位小数完整格式（比如详情页、表格合计行）。
  * - `sign`：`'none'`（默认）直接展示；`'positive'` 强制 + / -；`'negative'` 只在负值加 -。
  * - `tone`：`'default' | 'positive' | 'negative' | 'muted'`，语义色。
  * - `showCurrency`：是否在数字前展示币种符号（默认不展示，避免和 pill / 分组标题重复）。
  * - `size`：预设字号。业务不直接指定 tailwind text-\* 以免各处分散。
  *
- * 使用示例：
- *   <Amount value={1234567.89} />                     → ¥123.5万
+ * 使用示例(中文 locale)：
+ *   <Amount value={1234567.89} />                     → ¥123.5万   （英文 locale → ¥1.2M）
  *   <Amount value={-980} tone="negative" />           → -980.00
  *   <Amount value={0} compact={false} showCurrency /> → ¥0.00
  */
@@ -68,7 +73,14 @@ export function Amount({
   className,
   sign = 'auto'
 }: AmountProps) {
-  const text = renderAmount({ value, currency, compact, showCurrency, sign })
+  // chinese 决定算法分支(中文按「万」折算 / 英文按 k·M);万字字形(简体「万」、
+  // 繁体「萬」)是纯文案,统一从 i18n 取,不在 JS 里硬编码。英文 locale 下这个 key
+  // 返回 'k',但英文分支用不到 wanUnit,无副作用。
+  const { locale } = useLocale()
+  const t = useT()
+  const chinese = locale.startsWith('zh')
+  const wanUnit = t('common.unit.10k')
+  const text = renderAmount({ value, currency, compact, showCurrency, sign, chinese, wanUnit })
   const classes = [
     'font-mono tabular-nums',
     SIZE_CLASS[size],
@@ -86,13 +98,17 @@ function renderAmount({
   currency,
   compact,
   showCurrency,
-  sign
+  sign,
+  chinese,
+  wanUnit
 }: {
   value: number | null | undefined
   currency?: string | null
   compact: boolean
   showCurrency: boolean
   sign: 'auto' | 'always' | 'never'
+  chinese: boolean
+  wanUnit: string
 }): string {
   if (value === null || value === undefined || Number.isNaN(value)) return '-'
   const isNeg = value < 0
@@ -101,11 +117,9 @@ function renderAmount({
 
   let body: string
   if (compact) {
-    body = formatBalanceCompact(absVal, cur, {
-      chinese: (cur || currency || 'CNY').toUpperCase() === 'CNY'
-    })
+    body = formatBalanceCompact(absVal, cur, { chinese, wanUnit })
   } else {
-    const formatted = absVal.toLocaleString('zh-CN', {
+    const formatted = absVal.toLocaleString(chinese ? 'zh-CN' : 'en-US', {
       minimumFractionDigits: 2,
       maximumFractionDigits: 2
     })

--- a/frontend/packages/web-features/src/format.ts
+++ b/frontend/packages/web-features/src/format.ts
@@ -9,6 +9,7 @@ export function formatAmountCny(value: number | null | undefined): string {
  * 紧凑金额格式化（对齐 mobile `utils/format_utils.dart#formatBalance`）。
  *
  * - 中文环境：< 1 万保留两位；≥ 1 万按 1-2 位小数折算成 "X.X万"。
+ *   万字单位由 `wanUnit` 指定 —— zh-CN「万」/ zh-TW「萬」,默认「万」。
  * - 其他环境：≥ 100 万折算 M、≥ 1 千折算 k，< 1 千保留两位。
  * - currencyCode 传 null 时不带币种符号（BankCardTile 独立展示 currency pill，
  *   不想在金额字符串里再重复一次）。
@@ -16,7 +17,7 @@ export function formatAmountCny(value: number | null | undefined): string {
 export function formatBalanceCompact(
   value: number | null | undefined,
   currencyCode?: string | null,
-  opts?: { chinese?: boolean }
+  opts?: { chinese?: boolean; wanUnit?: string }
 ): string {
   if (value === null || value === undefined || Number.isNaN(value)) return '-'
   const chinese = opts?.chinese ?? true
@@ -33,7 +34,7 @@ export function formatBalanceCompact(
     const err1 = Math.abs(r1 * 10000 - absVal)
     const threshold = wan >= 10 ? 100 : 50
     const formatted = err1 > threshold ? wan.toFixed(2) : wan.toFixed(1)
-    return `${sign}${trimZero(formatted)}万`
+    return `${sign}${trimZero(formatted)}${opts?.wanUnit ?? '万'}`
   }
 
   if (absVal >= 1_000_000) {
@@ -49,6 +50,30 @@ export function formatBalanceCompact(
     return `${sign}${trimZero(formatted)}k`
   }
   return `${sign}${absVal.toFixed(2)}`
+}
+
+/**
+ * 紧凑「轴刻度」数字格式化 —— 图表 Y 轴 / 日历格这类不带币种、且小数值要求取整
+ * 的场景。和 `formatBalanceCompact` 的区别:小于缩写阈值时直接取整(轴刻度不需要
+ * 跟金额一样保留 .00)。
+ *
+ * - 中文环境(`chinese: true`):≥ 1 万 → "X.X<wanUnit>",单位文案由调用方传入
+ *   (zh-CN 用「万」、zh-TW 用「萬」,默认「万」)。
+ * - 英文环境(`chinese: false`):≥ 100 万 → "X.XM"、≥ 1 千 → "X.Xk",否则取整 ——
+ *   符合英文区习惯,不再出现「万」。
+ */
+export function formatCompactTick(
+  value: number,
+  opts: { chinese: boolean; wanUnit?: string }
+): string {
+  const abs = Math.abs(value)
+  if (opts.chinese) {
+    if (abs < 10000) return value.toFixed(0)
+    return `${(value / 10000).toFixed(1)}${opts.wanUnit ?? '万'}`
+  }
+  if (abs >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  if (abs >= 1000) return `${(value / 1000).toFixed(1)}k`
+  return value.toFixed(0)
 }
 
 function currencySymbol(code: string): string {


### PR DESCRIPTION
## 问题

紧凑金额的「万 / 萬 / k」单位之前**挂在币种上**(`currency === 'CNY'` 才走「万」),与界面语言无关。导致:

- **英文界面**下 CNY 账本仍显示 `¥247.25万`(应为 `¥2.47M`)
- **繁体界面**下显示简体「万」而非「萬」

另外两个图表 Y 轴在英文下 `÷10000` 却标 `k`,数字小了 10 倍(`50000` → `5.0k`,应为 `50k`)。

## 改动

- **算法分支**(中文折万 / 英文折 k·M)改由 **UI 语言**决定,不再看币种 —— `Amount` 组件用 `useLocale()`。
- **万字字形**(简体「万」/ 繁体「萬」/ 英文 `k`)收进中性 i18n key `common.unit.10k`,不在 JS 里硬编码(原先误挂在 `home.trendBars.*` 命名空间,一并提升)。
- 修复两个图表 Y 轴英文下的 10 倍偏小 bug(`MonthlyTrendBars` / `CategoryDetailDialog`)。
- 日历格 `compactNum` 加英文 k/M 分支。

四处金额出口统一:`Amount` 组件、月度走势图、分类详情图、日历格。

## 效果对照(截图里的实际数字)

| 原(任何语言) | zh-CN | zh-TW | en |
|---|---|---|---|
| 247.25万 | ¥247.25万 | ¥247.25萬 | ¥2.47M |
| 78.27万 | 78.27万 | 78.27萬 | 782.7k |

## 验证

- `pnpm -C apps/web build`(`tsc -b && vite build`)通过
- `pnpm -C apps/web test` 35/35 通过 —— 新增断言锁住 `2472500 → ¥2.47M`、`{wanUnit:'萬'} → ¥247.25萬`;i18n parity 测试确认 `common.unit.10k` 三语齐全

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 优化数字显示的国际化支持，根据用户语言环境自动调整单位格式（中文环境显示"万"，英文环境显示"k/M"）

* **测试**
  * 增加紧凑数字格式化在多语言环境下的测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->