### PR TITLE
fix(web): 信用卡资产展示对齐 App,去掉"累计收入"

### DIFF
--- a/frontend/apps/web/src/components/dialogs/AccountDetailDialog.tsx
+++ b/frontend/apps/web/src/components/dialogs/AccountDetailDialog.tsx
@@ -109,6 +109,24 @@ function AccountStatsHeader({
   const balance = hasServerStats ? account.balance! : account.initial_balance ?? 0
   const fmt = (v: number) =>
     v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+
+  // 信用卡按负债展示:只显当前欠款(= -balance,余额为负=欠款),不显示
+  // 累计收入/支出(信用卡入账是还款/退款,非收入);额度/可用/账单在下方
+  // AccountCardInfo。对齐 mobile account_detail_page。
+  if ((account.account_type || '') === 'credit_card') {
+    const owed = Math.max(0, -balance)
+    return (
+      <div className="border-b border-border/60 bg-muted/20 px-6 py-4 text-center">
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+          {t('accounts.bankcard.currentOwed')}
+        </div>
+        <div className="mt-0.5 font-mono text-lg font-bold tabular-nums text-expense">
+          {fmt(owed)}
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="grid grid-cols-3 gap-3 border-b border-border/60 bg-muted/20 px-6 py-4 text-center">
       <div>

--- a/frontend/apps/web/src/i18n/en.ts
+++ b/frontend/apps/web/src/i18n/en.ts
@@ -627,6 +627,8 @@ const en = {
   'accounts.bankcard.balance': 'Balance',
   'accounts.bankcard.income': 'Income',
   'accounts.bankcard.expense': 'Expense',
+  'accounts.bankcard.creditUsed': 'Used',
+  'accounts.bankcard.creditAvailable': 'Available',
   'accounts.bankcard.balanceLabel': 'Balance',
   'accounts.bankcard.owedLabel': 'Owed',
 

--- a/frontend/apps/web/src/i18n/zh-CN.ts
+++ b/frontend/apps/web/src/i18n/zh-CN.ts
@@ -172,6 +172,8 @@ const zhCN = {
   'accounts.bankcard.balance': '余额',
   'accounts.bankcard.income': '收入',
   'accounts.bankcard.expense': '支出',
+  'accounts.bankcard.creditUsed': '已用',
+  'accounts.bankcard.creditAvailable': '可用',
   'accounts.bankcard.balanceLabel': '余额',
   'accounts.bankcard.owedLabel': '欠款',
 

--- a/frontend/apps/web/src/i18n/zh-TW.ts
+++ b/frontend/apps/web/src/i18n/zh-TW.ts
@@ -626,6 +626,8 @@ const zhTW = {
   'accounts.bankcard.balance': '餘額',
   'accounts.bankcard.income': '收入',
   'accounts.bankcard.expense': '支出',
+  'accounts.bankcard.creditUsed': '已用',
+  'accounts.bankcard.creditAvailable': '可用',
   'accounts.bankcard.balanceLabel': '餘額',
   'accounts.bankcard.owedLabel': '欠款',
 

--- a/frontend/packages/web-features/src/features/AccountsPanel.tsx
+++ b/frontend/packages/web-features/src/features/AccountsPanel.tsx
@@ -437,6 +437,11 @@ function BankCardTile({
   const displayBalance = hasStats ? (row.balance as number) : row.initial_balance ?? 0
   // 估值账户：负债显示绝对值欠款，资产显示当前估值。
   const valuationValue = isLiability ? Math.abs(displayBalance) : displayBalance
+  // 信用卡：按负债展示。已用 = max(0, -balance),可用 = 额度 - 已用(对齐 mobile）。
+  const isCreditCard = accountType === 'credit_card'
+  const ccLimit = typeof row.credit_limit === 'number' ? row.credit_limit : null
+  const ccOwed = Math.max(0, -displayBalance)
+  const ccAvailable = ccLimit !== null ? Math.max(0, ccLimit - ccOwed) : null
 
   return (
     <div
@@ -530,6 +535,39 @@ function BankCardTile({
               className="mt-0.5 block text-[18px] leading-tight drop-shadow text-white"
             />
           </div>
+        ) : isCreditCard ? (
+          ccLimit !== null ? (
+            <div className="mt-auto grid grid-cols-3 gap-1 rounded-md bg-black/15 px-2 py-1.5 backdrop-blur-[1px]">
+              <StatCell
+                label={t('accounts.field.creditLimit')}
+                value={ccLimit}
+                currency={currency}
+              />
+              <StatCell
+                label={t('accounts.bankcard.creditUsed')}
+                value={ccOwed}
+                currency={currency}
+              />
+              <StatCell
+                label={t('accounts.bankcard.creditAvailable')}
+                value={ccAvailable as number}
+                currency={currency}
+              />
+            </div>
+          ) : (
+            <div className="mt-auto">
+              <div className="text-[9px] uppercase tracking-[0.15em] text-white/75">
+                {t('accounts.bankcard.currentOwed')}
+              </div>
+              <Amount
+                value={ccOwed}
+                currency={currency}
+                showCurrency
+                bold
+                className="mt-0.5 block text-[18px] leading-tight drop-shadow text-white"
+              />
+            </div>
+          )
         ) : hasStats ? (
           <div className="mt-auto grid grid-cols-3 gap-1 rounded-md bg-black/15 px-2 py-1.5 backdrop-blur-[1px]">
             <StatCell


### PR DESCRIPTION
## 改动
- **账户详情弹窗**:信用卡顶部改为「当前欠款」,不再显当前余额 / 累计收入 / 累计支出(信用卡入账是还款 / 退款,非收入);额度 / 可用 / 账单还款日保留。
- **资产页列表卡片**:信用卡显示 额度 / 已用 / 可用(无额度则显当前欠款),不再走余额 / 收入 / 支出。
- 口径同 mobile:已用 = max(0, -balance),可用 = 额度 − 已用;新增 i18n 已用 / 可用(zh-CN / zh-TW / en)。

## 验证
`tsc -b`(web app + web-features)无类型错误。仅类型检查,未起 web 实跑。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 信用卡账户现在支持专属展示逻辑，显示信用额度、已用金额和可用金额
  * 优化了信用卡账户的统计信息展示方式
  * 完善了英文、简体中文和繁体中文的多语言支持

<!-- end of auto-generated comment: release notes by coderabbit.ai -->