### PR TITLE
feat: 首页金额 odometer 滚动 + 统计卡级联入场动画

### DIFF
--- a/frontend/apps/web/src/components/dashboard/HomeHero.tsx
+++ b/frontend/apps/web/src/components/dashboard/HomeHero.tsx
@@ -159,6 +159,7 @@ export function HomeHero({
             currency={currency}
             size="4xl"
             bold
+            animate
             tone={balance >= 0 ? 'positive' : 'negative'}
             className="mt-1 block font-black tracking-tight"
           />
@@ -173,6 +174,7 @@ export function HomeHero({
                 currency={currency}
                 showCurrency
                 bold
+                animate
                 size="xl"
                 tone="positive"
                 className="mt-0.5 block leading-tight"
@@ -187,6 +189,7 @@ export function HomeHero({
                 currency={currency}
                 showCurrency
                 bold
+                animate
                 size="xl"
                 tone="negative"
                 className="mt-0.5 block leading-tight"

--- a/frontend/apps/web/src/components/dashboard/HomeHero.tsx
+++ b/frontend/apps/web/src/components/dashboard/HomeHero.tsx
@@ -168,6 +168,8 @@ export function HomeHero({
             <HeroStat
               icon={<ArrowDownLeft className="h-3.5 w-3.5 text-income" />}
               label={t('home.hero.income').replace('{scope}', scopeLabel)}
+              className="bee-rise-in"
+              style={{ animationDelay: '0ms' }}
             >
               <Amount
                 value={income}
@@ -175,6 +177,7 @@ export function HomeHero({
                 showCurrency
                 bold
                 animate
+                animateDelay={0.45}
                 size="xl"
                 tone="positive"
                 className="mt-0.5 block leading-tight"
@@ -183,6 +186,8 @@ export function HomeHero({
             <HeroStat
               icon={<ArrowUpRight className="h-3.5 w-3.5 text-expense" />}
               label={t('home.hero.expense').replace('{scope}', scopeLabel)}
+              className="bee-rise-in"
+              style={{ animationDelay: '110ms' }}
             >
               <Amount
                 value={expense}
@@ -190,6 +195,7 @@ export function HomeHero({
                 showCurrency
                 bold
                 animate
+                animateDelay={0.55}
                 size="xl"
                 tone="negative"
                 className="mt-0.5 block leading-tight"
@@ -198,6 +204,8 @@ export function HomeHero({
             <HeroStat
               icon={<Receipt className="h-3.5 w-3.5 text-amber-500" />}
               label={t('home.hero.count')}
+              className="bee-rise-in"
+              style={{ animationDelay: '220ms' }}
             >
               <div className="mt-0.5 font-mono text-xl font-bold tabular-nums leading-tight">
                 {txCount.toLocaleString()}
@@ -209,6 +217,8 @@ export function HomeHero({
             <HeroStat
               icon={<CalendarDays className="h-3.5 w-3.5 text-sky-500" />}
               label={t('home.hero.days')}
+              className="bee-rise-in"
+              style={{ animationDelay: '330ms' }}
             >
               <div className="mt-0.5 font-mono text-xl font-bold tabular-nums leading-tight">
                 {days.toLocaleString()}
@@ -339,14 +349,21 @@ function ScopeSwitcher({
 function HeroStat({
   icon,
   label,
-  children
+  children,
+  className,
+  style
 }: {
   icon: React.ReactNode
   label: string
   children: React.ReactNode
+  className?: string
+  style?: React.CSSProperties
 }) {
   return (
-    <div className="rounded-xl border border-border/40 bg-background/50 px-3 py-2 backdrop-blur-sm">
+    <div
+      className={`rounded-xl border border-border/40 bg-background/50 px-3 py-2 backdrop-blur-sm${className ? ` ${className}` : ''}`}
+      style={style}
+    >
       <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-muted-foreground">
         {icon}
         {label}

--- a/frontend/apps/web/src/styles.css
+++ b/frontend/apps/web/src/styles.css
@@ -135,3 +135,27 @@
     pointer-events: none;
   }
 }
+
+/* ===== 入场动画 ===== */
+/* 淡入 + 轻微上移。配合 inline `animation-delay` 做 stagger 级联(见 HomeHero)。 */
+.bee-rise-in {
+  animation: bee-rise-in 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@keyframes bee-rise-in {
+  from {
+    opacity: 0;
+    transform: translateY(14px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* 尊重系统"减少动态效果":直接展示终态,不做入场。 */
+@media (prefers-reduced-motion: reduce) {
+  .bee-rise-in {
+    animation: none;
+  }
+}

--- a/frontend/packages/web-features/src/components/Amount.tsx
+++ b/frontend/packages/web-features/src/components/Amount.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type CSSProperties } from 'react'
+import { useEffect, useRef, useState, type CSSProperties } from 'react'
 
 import { useReducedMotion } from 'framer-motion'
 
@@ -74,6 +74,8 @@ type AmountProps = {
   animate?: boolean
   /** 翻滚时长(秒),默认 0.6。 */
   animateDuration?: number
+  /** 首次翻滚前的延迟(秒),默认 0 —— 用于"卡片先入场、数字再滚动"的编排;后续数值变化不受影响,立即滚。 */
+  animateDelay?: number
 }
 
 export function Amount({
@@ -87,7 +89,8 @@ export function Amount({
   className,
   sign = 'auto',
   animate = false,
-  animateDuration = 0.6
+  animateDuration = 0.6,
+  animateDelay = 0
 }: AmountProps) {
   // chinese 决定算法分支(中文按「万」折算 / 英文按 k·M);万字字形(简体「万」、
   // 繁体「萬」)是纯文案,统一从 i18n 取,不在 JS 里硬编码。英文 locale 下这个 key
@@ -116,7 +119,7 @@ export function Amount({
   if (shouldRoll) {
     return (
       <span className={classes}>
-        <RollingNumber text={text} duration={animateDuration} />
+        <RollingNumber text={text} duration={animateDuration} delay={animateDelay} />
       </span>
     )
   }
@@ -142,13 +145,21 @@ const SR_ONLY: CSSProperties = {
  * 滚的是"终值字符串的每一位",所以不会出现 count-up 跨档位时
  * "¥9999.00 → ¥1万" 那种宽度/格式突变的抖动。
  */
-function RollingNumber({ text, duration }: { text: string; duration: number }) {
+function RollingNumber({
+  text,
+  duration,
+  delay
+}: {
+  text: string
+  duration: number
+  delay: number
+}) {
   return (
     <span style={{ lineHeight: 1, whiteSpace: 'nowrap' }}>
       <span style={SR_ONLY}>{text}</span>
       {text.split('').map((ch, i) =>
         ch >= '0' && ch <= '9' ? (
-          <RollingDigit key={i} digit={Number(ch)} duration={duration} />
+          <RollingDigit key={i} digit={Number(ch)} duration={duration} delay={delay} />
         ) : (
           <span
             key={i}
@@ -164,13 +175,27 @@ function RollingNumber({ text, duration }: { text: string; duration: number }) {
 }
 
 /** 单个数字位:0-9 竖排成一列,translateY 把目标数字滚动到可视窗口。 */
-function RollingDigit({ digit, duration }: { digit: number; duration: number }) {
-  // 初值 0,挂载后下一帧再设目标值,让首次出现也有"从 0 滚入"的效果。
+function RollingDigit({
+  digit,
+  duration,
+  delay
+}: {
+  digit: number
+  duration: number
+  delay: number
+}) {
+  // 初值 0;首次挂载等 delay 秒后再滚(让卡片入场先走完),之后的数值变化立即滚。
   const [shown, setShown] = useState(0)
+  const mounted = useRef(false)
   useEffect(() => {
-    const id = requestAnimationFrame(() => setShown(digit))
-    return () => cancelAnimationFrame(id)
-  }, [digit])
+    if (mounted.current) {
+      setShown(digit)
+      return
+    }
+    mounted.current = true
+    const id = setTimeout(() => setShown(digit), delay * 1000)
+    return () => clearTimeout(id)
+  }, [digit, delay])
   return (
     <span
       aria-hidden

--- a/frontend/packages/web-features/src/components/Amount.tsx
+++ b/frontend/packages/web-features/src/components/Amount.tsx
@@ -1,3 +1,7 @@
+import { useEffect, useState, type CSSProperties } from 'react'
+
+import { useReducedMotion } from 'framer-motion'
+
 import { useLocale, useT } from '@beecount/ui'
 
 import { formatBalanceCompact } from '../format'
@@ -60,6 +64,16 @@ type AmountProps = {
    * `'never'`：永远不加符号。
    */
   sign?: 'auto' | 'always' | 'never'
+  /**
+   * 数字是否做"上下翻页"(odometer 滚轮)动画 —— 每个数字位垂直滚动到目标值,
+   * 非数字字符(¥ / 万 / k·M / 小数点 / 正负号)保持不动。先用 renderAmount 算出
+   * 终值字符串再逐位滚动,因此业务格式完整保留,也不会跨"万"档位时抖动。
+   * 默认 false —— 仅在仪表盘大数字等高价值位置显式开启,列表/表格保持安静。
+   * 自动尊重 prefers-reduced-motion(命中时直接展示终值,不滚动)。
+   */
+  animate?: boolean
+  /** 翻滚时长(秒),默认 0.6。 */
+  animateDuration?: number
 }
 
 export function Amount({
@@ -71,7 +85,9 @@ export function Amount({
   size = 'md',
   bold = false,
   className,
-  sign = 'auto'
+  sign = 'auto',
+  animate = false,
+  animateDuration = 0.6
 }: AmountProps) {
   // chinese 决定算法分支(中文按「万」折算 / 英文按 k·M);万字字形(简体「万」、
   // 繁体「萬」)是纯文案,统一从 i18n 取,不在 JS 里硬编码。英文 locale 下这个 key
@@ -80,6 +96,7 @@ export function Amount({
   const t = useT()
   const chinese = locale.startsWith('zh')
   const wanUnit = t('common.unit.10k')
+
   const text = renderAmount({ value, currency, compact, showCurrency, sign, chinese, wanUnit })
   const classes = [
     'font-mono tabular-nums',
@@ -90,7 +107,97 @@ export function Amount({
   ]
     .filter(Boolean)
     .join(' ')
+
+  // "上下翻页":只在显式开启 + 允许动效 + 是有限数值时启用,否则渲染静态文本。
+  const reduceMotion = useReducedMotion()
+  const numeric = typeof value === 'number' && Number.isFinite(value)
+  const shouldRoll = animate && !reduceMotion && numeric
+
+  if (shouldRoll) {
+    return (
+      <span className={classes}>
+        <RollingNumber text={text} duration={animateDuration} />
+      </span>
+    )
+  }
   return <span className={classes}>{text}</span>
+}
+
+// 屏幕阅读器读完整终值;逐位滚动的可见部分全部 aria-hidden。
+const SR_ONLY: CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0
+}
+
+/**
+ * 把已格式化好的金额字符串(如 "¥1.2万" / "-$50k" / "¥980.00")逐字符渲染:
+ * 数字位用 odometer 滚轮上下翻页,其余字符(符号 / 小数点 / 万·k·M)保持静止。
+ * 滚的是"终值字符串的每一位",所以不会出现 count-up 跨档位时
+ * "¥9999.00 → ¥1万" 那种宽度/格式突变的抖动。
+ */
+function RollingNumber({ text, duration }: { text: string; duration: number }) {
+  return (
+    <span style={{ lineHeight: 1, whiteSpace: 'nowrap' }}>
+      <span style={SR_ONLY}>{text}</span>
+      {text.split('').map((ch, i) =>
+        ch >= '0' && ch <= '9' ? (
+          <RollingDigit key={i} digit={Number(ch)} duration={duration} />
+        ) : (
+          <span
+            key={i}
+            aria-hidden
+            style={{ display: 'inline-block', verticalAlign: 'bottom', lineHeight: 1 }}
+          >
+            {ch}
+          </span>
+        )
+      )}
+    </span>
+  )
+}
+
+/** 单个数字位:0-9 竖排成一列,translateY 把目标数字滚动到可视窗口。 */
+function RollingDigit({ digit, duration }: { digit: number; duration: number }) {
+  // 初值 0,挂载后下一帧再设目标值,让首次出现也有"从 0 滚入"的效果。
+  const [shown, setShown] = useState(0)
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setShown(digit))
+    return () => cancelAnimationFrame(id)
+  }, [digit])
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: 'inline-block',
+        height: '1em',
+        overflow: 'hidden',
+        verticalAlign: 'bottom',
+        lineHeight: 1
+      }}
+    >
+      <span
+        style={{
+          display: 'block',
+          transform: `translateY(-${shown}em)`,
+          transition: `transform ${duration}s cubic-bezier(0.16, 1, 0.3, 1)`,
+          willChange: 'transform'
+        }}
+      >
+        {Array.from({ length: 10 }, (_, i) => (
+          <span key={i} style={{ display: 'block', height: '1em', lineHeight: 1 }}>
+            {i}
+          </span>
+        ))}
+      </span>
+    </span>
+  )
 }
 
 function renderAmount({


### PR DESCRIPTION
首页(Overview / HomeHero)两处轻量动画:

- **数字滚动**:结余 / 收入 / 支出改为 odometer 上下翻页(逐位滚动,保留 ¥/万/k·M/符号格式,跨档位不抖动)。
- **统计卡入场**:收入 / 支出 / 笔数 / 天数四卡级联淡入;数字滚动编排在各自卡片入场之后,避免两种动画抢戏。

纯 CSS + 复用现有 framer-motion 的 `useReducedMotion`,全部尊重 `prefers-reduced-motion`;**无新增依赖**。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 仪表板主页统计数据新增入场动画效果，提升视觉体验
  * 金额显示支持数字逐位滚动动画，使数值变化更具可视化
  * 完整支持系统"减少动画"偏好设置，确保用户体验的个性化和易用性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->