### PR TITLE
fix(ai): 推理模型锁 temperature 时自适应摘参数重试 (kimi-k2.5)

### DIFF
--- a/src/routers/ai/test_provider.py
+++ b/src/routers/ai/test_provider.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field
 from ...config import get_settings
 from ...deps import get_current_user
 from ...models import User
+from ...services.ai.provider_client import _post_chat_adaptive
 from ...services.ai.test_samples import (
     TEST_JPEG_DATA_URL,
     TEST_WAV_BYTES,
@@ -97,6 +98,12 @@ def _classify_error(status_code: int, body: str) -> str:
     if status_code == 404:
         return "AI_TEST_MODEL_NOT_FOUND"
     if status_code in (400, 422):
+        # 参数类错误(如推理模型锁 temperature:"invalid temperature ... for this model")
+        # 同时含 "model" + "invalid",会被下面的规则误判成「模型未找到」。正常路径已由
+        # _post_chat_adaptive 自适应摘参数;这里兜底,把它如实归到 UNKNOWN(前端显示原始
+        # error_message),别再误导用户去查模型名。
+        if "temperature" in body_lower:
+            return "AI_TEST_UNKNOWN"
         # 常见:model not found / model not supported
         if "model" in body_lower and ("not" in body_lower or "invalid" in body_lower or "support" in body_lower):
             return "AI_TEST_MODEL_NOT_FOUND"
@@ -219,18 +226,16 @@ async def _test_text(base_url: str, api_key: str, model: str) -> str:
         "max_tokens": 16,
         "temperature": 0.2,
     }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
     async with httpx.AsyncClient(
         timeout=15.0,
         verify=get_settings().ai_http_verify_ssl,
     ) as client:
-        resp = await client.post(
-            url,
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            },
-            json=payload,
-        )
+        # 推理模型(kimi-k2.5 等)锁 temperature → 被拒时自适应摘掉重发
+        resp = await _post_chat_adaptive(client, url, headers, payload)
     if resp.status_code >= 400:
         raise _UpstreamHTTPError(resp.status_code, resp.text)
     data = resp.json()
@@ -254,18 +259,15 @@ async def _test_vision(base_url: str, api_key: str, model: str) -> str:
         "max_tokens": 16,
         "temperature": 0.2,
     }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
     async with httpx.AsyncClient(
         timeout=20.0,
         verify=get_settings().ai_http_verify_ssl,
     ) as client:
-        resp = await client.post(
-            url,
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            },
-            json=payload,
-        )
+        resp = await _post_chat_adaptive(client, url, headers, payload)
     if resp.status_code >= 400:
         raise _UpstreamHTTPError(resp.status_code, resp.text)
     data = resp.json()

--- a/src/services/ai/provider_client.py
+++ b/src/services/ai/provider_client.py
@@ -244,6 +244,76 @@ class JsonParseFailedError(ChatProviderError):
         self.raw_content = raw_content
 
 
+# 自适应参数剥离 ────────────────────────────────────────────────────────────
+#
+# 不同模型对 OpenAI-compatible 参数有不同约束:推理模型(kimi-k2.5 / o1 / o3 /
+# DeepSeek-R1)把 temperature 锁死成 1,拒绝其他值;部分模型不支持 response_format。
+# 与其按模型/参数名写死兼容分支,不如「听上游报错动态适配」:上游因某个参数报错时
+# 它会点名是哪个参数,我们照它说的把那个参数摘掉重发。
+
+# 结构上必须保留的键;其余键(temperature / top_p / response_format / max_tokens …)
+# 都是「可丢的可选参数」:被上游拒绝时摘掉重发。
+_REQUIRED_KEYS = frozenset({"model", "messages", "stream"})
+# 防止烂网关让我们无限摘参数空转
+_MAX_PARAM_STRIPS = 3
+
+
+def _rejected_param(payload: dict, status_code: int, body: str) -> str | None:
+    """上游因「参数不合法」报错时,返回它点名的那个参数(且必须是我们发出去的可丢键)。
+
+    优先结构化 error.param(OpenAI / o1 / o3 错误体里直接给 ``"param": "temperature"``);
+    没有该字段(Moonshot 那种 ``invalid temperature: only 1 is allowed for this model``)
+    就扫错误文案里点了我们发出去的哪个键。
+
+    返回 None = 不是参数问题 / 点名的是必须键 / 没的可摘了 → 交给上层照常报错。
+    """
+    if status_code < 400:
+        return None
+    # 1) 结构化:{"error": {"param": "temperature", ...}}
+    try:
+        err = json.loads(body).get("error")
+        if isinstance(err, dict):
+            param = err.get("param")
+            if isinstance(param, str) and param in payload and param not in _REQUIRED_KEYS:
+                return param
+    except (ValueError, TypeError, AttributeError):
+        pass
+    # 2) 文案兜底:错误信息点了我们发出去的哪个可丢键
+    low = body.lower()
+    for key in payload:
+        if key not in _REQUIRED_KEYS and key.lower() in low:
+            return key
+    return None
+
+
+async def _post_chat_adaptive(
+    client: httpx.AsyncClient, url: str, headers: dict, payload: dict,
+) -> httpx.Response:
+    """POST /chat/completions;若上游因某个可选参数报 4xx,摘掉它重发,最多 _MAX_PARAM_STRIPS 次。
+
+    普通模型:参数都合法 → 一次成功,行为完全不变。
+    推理模型(k2.5 / o1 / o3 / R1):温度等被锁 → 摘掉 → 用模型默认值,通过。
+
+    只在「拿到响应且是参数类错误」时重试;超时 / 网络异常照常向上抛(由调用方处理)。
+    """
+    payload = dict(payload)  # 不改调用方的 dict
+    resp = await client.post(url, headers=headers, json=payload)
+    for _ in range(_MAX_PARAM_STRIPS):
+        if resp.status_code < 400:
+            return resp
+        param = _rejected_param(payload, resp.status_code, resp.text)
+        if param is None:
+            return resp  # 不是参数问题 / 没的可摘 → 原样返回,交给上层报错
+        logger.info(
+            "ai.param_stripped param=%s model=%s status=%d",
+            param, payload.get("model"), resp.status_code,
+        )
+        # 重建(而非 in-place pop):每次 POST 用独立 dict,不改已发出去的引用
+        payload = {k: v for k, v in payload.items() if k != param}
+        resp = await client.post(url, headers=headers, json=payload)
+    return resp  # 摘到上限仍失败,返回最后一次让上层报错
+
+
 async def call_chat_json(
     *,
     config: ChatProviderConfig,
@@ -268,7 +338,9 @@ async def call_chat_json(
     }
 
     for attempt in range(max_retries + 1):
-        # 重试时降 temperature + 去掉 response_format(兼容性更好)
+        # attempt 0 带 response_format;重试(解析失败 / 超时)降 temperature 并去掉
+        # response_format。参数被模型拒绝(如推理模型锁 temperature、不支持 response_format)
+        # 由 _post_chat_adaptive 在单次调用内自适应摘除,不依赖 attempt 切换。
         temperature = 0.2 if attempt == 0 else 0.05
         payload: dict[str, object] = {
             "model": config.model,
@@ -289,26 +361,16 @@ async def call_chat_json(
                 timeout=timeout,
                 verify=get_settings().ai_http_verify_ssl,
             ) as client:
-                resp = await client.post(url, headers=headers, json=payload)
+                resp = await _post_chat_adaptive(client, url, headers, payload)
             elapsed = time.monotonic() - t0
             logger.info(
                 "ai.call_chat_json done attempt=%d status=%d elapsed=%.2fs body_len=%d",
                 attempt + 1, resp.status_code, elapsed, len(resp.text),
             )
             if resp.status_code >= 400:
-                body = resp.text
-                # 400/422/不支持 response_format → 让 retry 跑(下一轮去掉这参数)
-                if attempt < max_retries and resp.status_code in (400, 422):
-                    last_exc = ChatProviderError(
-                        f"provider returned {resp.status_code}: {body[:200]}"
-                    )
-                    logger.warning(
-                        "ai.call_chat_json got %d, will retry without response_format",
-                        resp.status_code,
-                    )
-                    continue
+                # 参数类 4xx 已由 _post_chat_adaptive 摘参数重试过;到这说明不是参数问题
                 raise ChatProviderError(
-                    f"provider {config.provider_id} returned {resp.status_code}: {body[:200]}"
+                    f"provider {config.provider_id} returned {resp.status_code}: {resp.text[:200]}"
                 )
             data = resp.json()
             content = (
@@ -386,32 +448,49 @@ async def stream_chat_completion(
             timeout=timeout,
             verify=get_settings().ai_http_verify_ssl,
         ) as client:
-            async with client.stream("POST", url, headers=headers, json=payload) as resp:
-                if resp.status_code >= 400:
-                    body = (await resp.aread()).decode("utf-8", errors="replace")
-                    raise ChatProviderError(
-                        f"provider {config.provider_id} returned {resp.status_code}: {body[:200]}"
-                    )
-                async for line in resp.aiter_lines():
-                    if not line:
-                        continue
-                    line = line.strip()
-                    if not line.startswith("data:"):
-                        continue
-                    payload_str = line[len("data:"):].strip()
-                    if payload_str == "[DONE]":
-                        break
-                    try:
-                        chunk = json.loads(payload_str)
-                    except (ValueError, TypeError):
-                        logger.warning("ai.chat malformed SSE chunk: %s", payload_str[:80])
-                        continue
-                    choices = chunk.get("choices") or []
-                    if not choices:
-                        continue
-                    delta = choices[0].get("delta") or {}
-                    content = delta.get("content")
-                    if content:
-                        yield content
+            # 参数被模型拒绝(如推理模型锁 temperature)→ 摘掉重开一次流。
+            attempt_payload = dict(payload)
+            for _ in range(_MAX_PARAM_STRIPS + 1):
+                async with client.stream("POST", url, headers=headers, json=attempt_payload) as resp:
+                    if resp.status_code >= 400:
+                        body = (await resp.aread()).decode("utf-8", errors="replace")
+                        param = _rejected_param(attempt_payload, resp.status_code, body)
+                        if param is None:
+                            raise ChatProviderError(
+                                f"provider {config.provider_id} returned {resp.status_code}: {body[:200]}"
+                            )
+                        logger.info(
+                            "ai.stream_param_stripped param=%s model=%s status=%d",
+                            param, attempt_payload.get("model"), resp.status_code,
+                        )
+                        attempt_payload = {
+                            k: v for k, v in attempt_payload.items() if k != param
+                        }
+                        continue  # 摘掉该参数,重开流
+                    async for line in resp.aiter_lines():
+                        if not line:
+                            continue
+                        line = line.strip()
+                        if not line.startswith("data:"):
+                            continue
+                        payload_str = line[len("data:"):].strip()
+                        if payload_str == "[DONE]":
+                            break
+                        try:
+                            chunk = json.loads(payload_str)
+                        except (ValueError, TypeError):
+                            logger.warning("ai.chat malformed SSE chunk: %s", payload_str[:80])
+                            continue
+                        choices = chunk.get("choices") or []
+                        if not choices:
+                            continue
+                        delta = choices[0].get("delta") or {}
+                        content = delta.get("content")
+                        if content:
+                            yield content
+                    return  # 流正常结束
+            raise ChatProviderError(
+                f"provider {config.provider_id} stream failed after stripping params"
+            )
     except httpx.HTTPError as exc:
         raise ChatProviderError(f"network error: {exc}") from exc

--- a/tests/test_ai_provider_client_adaptive.py
+++ b/tests/test_ai_provider_client_adaptive.py
@@ -1,0 +1,89 @@
+"""自适应参数剥离单元测试(issue #312)。
+
+覆盖真实记账解析路径 `call_chat_json` 与 `_rejected_param` 的分类逻辑:
+推理模型(kimi-k2.5 / o1 / o3 / R1)锁 temperature → 被拒时摘掉重发,无需真实 key。
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import httpx
+
+from src.services.ai.provider_client import (
+    ChatProviderConfig,
+    _rejected_param,
+    call_chat_json,
+)
+
+_MOONSHOT_TEMP_ERR = (
+    '{"error":{"message":"invalid temperature: only 1 is allowed for this model",'
+    '"type":"invalid_request_error"}}'
+)
+
+
+# ──────────────── _rejected_param 分类 ────────────────
+
+
+def test_rejected_param_structured_error_param():
+    """OpenAI/o1/o3 错误体直接给 error.param。"""
+    body = '{"error":{"param":"temperature","message":"unsupported value","code":"unsupported_value"}}'
+    assert _rejected_param({"temperature": 0.2, "model": "o1"}, 400, body) == "temperature"
+
+
+def test_rejected_param_text_fallback_moonshot():
+    """Moonshot 不给 param,扫文案点名了哪个我们发出去的键。"""
+    assert _rejected_param({"temperature": 0.2, "model": "kimi-k2.5"}, 400, _MOONSHOT_TEMP_ERR) == "temperature"
+
+
+def test_rejected_param_never_strips_required_key():
+    """'model not found' 含 'model',但 model 是必须键 → 不摘,返回 None。"""
+    assert _rejected_param({"model": "missing", "messages": []}, 404, '{"error":"model not found"}') is None
+
+
+def test_rejected_param_non_param_error_returns_none():
+    """错误没点名我们发的任何可丢键 → None,交给上层照常报错。"""
+    assert _rejected_param({"temperature": 0.2, "model": "x"}, 429, '{"error":"rate limited"}') is None
+
+
+def test_rejected_param_success_status_returns_none():
+    assert _rejected_param({"temperature": 0.2}, 200, "") is None
+
+
+def test_rejected_param_response_format():
+    """同一机制覆盖 response_format 不被支持的 provider。"""
+    body = '{"error":{"message":"response_format is not supported by this model"}}'
+    payload = {"model": "x", "messages": [], "response_format": {"type": "json_object"}}
+    assert _rejected_param(payload, 400, body) == "response_format"
+
+
+# ──────────────── call_chat_json 真实解析路径 ────────────────
+
+
+def test_call_chat_json_strips_temperature_and_succeeds():
+    """带温度 → 400 → 摘温度重发 → 返回解析好的 JSON。"""
+    calls: list[dict | None] = []
+
+    async def fake_post(self, url, headers=None, json=None, **_):
+        calls.append(dict(json) if json else None)
+        if json is not None and "temperature" in json:
+            return httpx.Response(400, text=_MOONSHOT_TEMP_ERR)
+        return httpx.Response(
+            200, json={"choices": [{"message": {"content": '{"ok": true}'}}]}
+        )
+
+    cfg = ChatProviderConfig(
+        provider_id="p1",
+        base_url="https://api.moonshot.cn/v1",
+        api_key="sk-x",
+        model="kimi-k2.5",
+    )
+    with patch("httpx.AsyncClient.post", fake_post):
+        result = asyncio.run(
+            call_chat_json(config=cfg, messages=[{"role": "user", "content": "hi"}])
+        )
+
+    assert result == {"ok": True}
+    assert len(calls) == 2                       # 带温度→被拒,不带温度→成功
+    assert "temperature" in calls[0]
+    assert "temperature" not in calls[1]

--- a/tests/test_ai_test_provider.py
+++ b/tests/test_ai_test_provider.py
@@ -318,6 +318,54 @@ def test_rate_limit_after_30_requests():
 # ──────────────────── 字段校验 ────────────────────
 
 
+# ──────────────────── 参数自适应(issue #312) ────────────────────
+
+
+def test_temperature_rejected_retries_without_it():
+    """复现 Moonshot kimi-k2.5:带温度 → 400「only 1 is allowed」→ 摘掉温度重发 → 成功。
+
+    推理模型把 temperature 锁死成 1,我们发的低温被拒。无需真实 Kimi key,
+    伪造上游响应即可:带 temperature → 400;不带 → 200。
+    """
+    calls: list[dict | None] = []
+
+    async def fake_post(self, url, headers=None, json=None, **_):
+        calls.append(json)
+        if json is not None and "temperature" in json:
+            return httpx.Response(
+                400,
+                text='{"error":{"message":"invalid temperature: only 1 is allowed for this model","type":"invalid_request_error"}}',
+            )
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "hi"}}]},
+        )
+
+    client = _make_client()
+    try:
+        token = _register_and_login(client, "temp1@test.com")
+        with patch("httpx.AsyncClient.post", fake_post):
+            r = client.post(
+                "/api/v1/ai/test-provider",
+                json={
+                    "provider": {
+                        "apiKey": "sk-x",
+                        "baseUrl": "https://api.moonshot.cn/v1",
+                        "textModel": "kimi-k2.5",
+                    },
+                    "capability": "text",
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        body = r.json()
+        assert body["success"] is True, body          # 最终成功
+        assert len(calls) == 2                          # 带温度→被拒,不带温度→成功
+        assert "temperature" in calls[0]                # 第一次带了温度
+        assert "temperature" not in calls[1]            # 重试摘掉了温度
+    finally:
+        app.dependency_overrides.clear()
+
+
 def test_vision_capability_with_empty_model_returns_missing_fields():
     client = _make_client()
     try:


### PR DESCRIPTION
## 背景

关联 issue: **TNT-Likely/BeeCount#312** —— 用户添加 Moonshot `kimi-k2.5` 报错无法添加。

`kimi-k2.5`(以及 OpenAI o1/o3、DeepSeek-R1 等**推理模型**)把 `temperature` **锁死成只能 = 1**,发其他值直接 400:

```
400: {"error":{"message":"invalid temperature: only 1 is allowed for this model","type":"invalid_request_error"}}
```

而 server 各处硬编码了非 1 的低温,且无处可改 → 这类模型**测试 + 真实记账全部失败**:

| 位置 | 值 | 场景 |
|---|---|---|
| `test_provider.py` `_test_text` / `_test_vision` | `0.2` | Web 添加/测试(就是 issue 截图那一下) |
| `provider_client.py` `call_chat_json` | `0.2`→`0.05` | 真实记账解析 |
| `provider_client.py` `stream_chat_completion` | `0.3` | 文档问答流式 |

> 这不是「不支持高温」——`temperature=1` 是推理模型的形式约束,不是创造性档位。本 PR **不新增任何用户可见的温度旋钮**,记账仍走低温。

## 方案:听上游报错动态适配(不写死参数名/模型名)

与其按模型或参数名写死兼容分支,不如**让上游告诉我们哪个参数有问题**:4xx 错误里它会点名(结构化 `error.param`,或错误文案点了我们发出去的哪个键),照它说的把那个参数摘掉重发。

- 新增 `_rejected_param` + `_post_chat_adaptive`(`provider_client.py`),`call_chat_json` 接入,并**并掉了旧的 `response_format` 硬编码重试**(同款补丁,归入通用机制)。
- 流式 `stream_chat_completion` 内联同一逻辑(摘参数重开流)。
- `_test_text` / `_test_vision` 走 helper;`_classify_error` 不再把 temperature 错误误判成「模型未找到 / 不支持」。

## 为什么对老用户零影响

新逻辑**只在收到 4xx 时才触发**。普通模型(GLM / GPT / DeepSeek-V3 …)的成功调用是「POST 一次 → 拿到 <400 → 直接返回」,**根本不进摘参数/文案扫描那段代码**,温度仍是 0.2,行为逐字节不变。摘参数误判最坏 = 多发一次仍失败 → 抛真实错误,永不比现状更糟。

## 测试

无需真实 Kimi key —— 伪造上游响应复现 `kimi-k2.5`(带温度→400→摘温度重发→成功):

- `tests/test_ai_test_provider.py::test_temperature_rejected_retries_without_it`(端点路径)
- `tests/test_ai_provider_client_adaptive.py`(`call_chat_json` 真实解析路径 + `_rejected_param` 分类边界)

全量 `pytest tests/` 通过(323 passed)。

## 范围

本 PR 只修 **server**(解开 Web 添加 + 云端记账)。**mobile(Flutter)** 端同款硬编码(`ai_provider_factory.dart`)将在 `TNT-Likely/BeeCount` 仓另开 PR 按同一机制修复。

Refs TNT-Likely/BeeCount#312