### PR TITLE
fix(import): 云端 CSV 导入按客户端时区换算时间,修复晚 8 小时

### DIFF
--- a/frontend/packages/api-client/src/import.ts
+++ b/frontend/packages/api-client/src/import.ts
@@ -126,6 +126,9 @@ export async function uploadImport(
   const form = new FormData()
   form.append('file', options.file)
   if (options.targetLedgerId) form.append('target_ledger_id', options.targetLedgerId)
+  // CSV/Excel 里的时间是用户本地墙钟,带上浏览器时区偏移(东为正,UTC+8 = 480),
+  // 让后端从上传起就正确换算成 UTC,sample/preview/execute 全程一致(issue #314)。
+  form.append('tz_offset_minutes', String(-new Date().getTimezoneOffset()))
   const response = await fetch(`${API_BASE}/import/upload`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` },

--- a/frontend/packages/api-client/src/import.ts
+++ b/frontend/packages/api-client/src/import.ts
@@ -28,6 +28,12 @@ export type ImportFieldMapping = {
   datetime_format: string | null
   strip_currency_symbols: boolean
   expense_is_negative: boolean
+  /**
+   * 客户端本地时区相对 UTC 的分钟偏移(东为正,UTC+8 = 480)。CSV 里的时间是
+   * 用户本地墙钟,后端据此换算成 UTC 存储,避免被当作 UTC 整体偏移(issue #314)。
+   * 由 api-client 在 preview 时自动注入 -new Date().getTimezoneOffset(),UI 无需关心。
+   */
+  tz_offset_minutes?: number | null
 }
 
 export type ImportEntityDiff = {
@@ -144,7 +150,15 @@ export async function previewImport(
   options: PreviewImportOptions,
 ): Promise<ImportSummary> {
   const body: Record<string, unknown> = {}
-  if (options.mapping) body.mapping = options.mapping
+  if (options.mapping) {
+    // CSV 里的时间是用户本地墙钟,带上浏览器时区偏移(东为正,UTC+8 = 480),
+    // 让后端正确换算成 UTC,避免导入后整体偏移(issue #314)。
+    body.mapping = {
+      ...options.mapping,
+      tz_offset_minutes:
+        options.mapping.tz_offset_minutes ?? -new Date().getTimezoneOffset(),
+    }
+  }
   if (options.targetLedgerId !== undefined) body.target_ledger_id = options.targetLedgerId
   if (options.dedupStrategy !== undefined) body.dedup_strategy = options.dedupStrategy
   if (options.autoTagNames !== undefined) body.auto_tag_names = options.autoTagNames

--- a/src/routers/import_data/endpoints.py
+++ b/src/routers/import_data/endpoints.py
@@ -76,6 +76,9 @@ class FieldMappingPayload(BaseModel):
     datetime_format: str | None = None
     strip_currency_symbols: bool = True
     expense_is_negative: bool = False
+    # 客户端本地时区相对 UTC 的分钟偏移(东为正,UTC+8 = 480);用于把 CSV 本地
+    # 时间正确换算成 UTC(issue #314)。前端传 -new Date().getTimezoneOffset()。
+    tz_offset_minutes: int | None = None
 
     def to_internal(self) -> ImportFieldMapping:
         return ImportFieldMapping(
@@ -92,6 +95,7 @@ class FieldMappingPayload(BaseModel):
             datetime_format=self.datetime_format,
             strip_currency_symbols=self.strip_currency_symbols,
             expense_is_negative=self.expense_is_negative,
+            tz_offset_minutes=self.tz_offset_minutes,
         )
 
 
@@ -110,6 +114,7 @@ def _mapping_to_payload(m: ImportFieldMapping) -> dict:
         "datetime_format": m.datetime_format,
         "strip_currency_symbols": m.strip_currency_symbols,
         "expense_is_negative": m.expense_is_negative,
+        "tz_offset_minutes": m.tz_offset_minutes,
     }
 
 

--- a/src/routers/import_data/endpoints.py
+++ b/src/routers/import_data/endpoints.py
@@ -155,6 +155,9 @@ async def upload_import(
     request: Request,
     file: UploadFile = File(...),
     target_ledger_id: str | None = Form(default=None),
+    # 客户端本地时区相对 UTC 的分钟偏移(东为正,UTC+8 = 480)。CSV/Excel 里的
+    # 时间是用户本地墙钟,据此换算成 UTC(issue #314)。None = 老客户端未传。
+    tz_offset_minutes: int | None = Form(default=None),
     _scopes: set[str] = Depends(_WRITE_SCOPE_DEP),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -214,6 +217,10 @@ async def upload_import(
                 "limit_rows": _MAX_ROW_COUNT,
             },
         )
+
+    # 把客户端时区偏移写进 suggested_mapping —— sample_transactions / 后续
+    # preview / execute 全程继承,避免本地时间被当 UTC 整体偏移(issue #314)。
+    data.suggested_mapping.tz_offset_minutes = tz_offset_minutes
 
     # 校验 target_ledger_id(可空 — 用户可在 preview 阶段再选)
     target_ext_id = (target_ledger_id or "").strip() or None

--- a/src/services/import_data/schema.py
+++ b/src/services/import_data/schema.py
@@ -78,6 +78,10 @@ class ImportFieldMapping:
     datetime_format: str | None = None
     strip_currency_symbols: bool = True
     expense_is_negative: bool = False
+    # 客户端本地时区相对 UTC 的分钟偏移(东为正,UTC+8 = 480)。CSV 里的时间是
+    # 用户本地墙钟,据此换算成 UTC 存储;None = 老客户端未传,退回"当作 UTC"。
+    # 详见 transformer._localize_naive(issue #314)。
+    tz_offset_minutes: int | None = None
 
     @property
     def required_complete(self) -> bool:

--- a/src/services/import_data/transformer.py
+++ b/src/services/import_data/transformer.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 from typing import Iterable
 
@@ -132,7 +132,7 @@ def _transform_row(row: ParsedRow, mapping: ImportFieldMapping) -> ImportTransac
     if not raw_dt:
         raise _RowError("PARSE_MISSING_REQUIRED", "happened_at",
                         "happened_at is empty")
-    dt = _parse_datetime(raw_dt, mapping.datetime_format)
+    dt = _parse_datetime(raw_dt, mapping.datetime_format, mapping.tz_offset_minutes)
     if dt is None:
         raise _RowError("PARSE_INVALID_FIELD", "happened_at",
                         f"could not parse datetime {raw_dt!r}")
@@ -228,34 +228,46 @@ def _parse_amount(raw: str, strip_currency: bool) -> tuple[Decimal, bool]:
     return d, is_negative
 
 
-def _parse_datetime(raw: str, fmt: str | None) -> datetime | None:
+def _localize_naive(dt: datetime, tz_offset_minutes: int | None) -> datetime:
+    """把 strptime/fromisoformat 出来的 naive datetime 转成 aware UTC。
+
+    CSV 里的时间是用户【本地墙钟】(无时区信息)。tz_offset_minutes 是客户端传来的
+    本地相对 UTC 的分钟偏移(东为正,UTC+8 = 480),据此把墙钟换算成 UTC 存储,
+    避免被下游"naive 一律当 UTC"的序列化逻辑整体偏移(issue #314:之前直接
+    replace(tzinfo=utc),把 23:16 本地当成 23:16 UTC,客户端 toLocal 后晚 8 小时)。
+
+    - 已带时区(strptime %z / fromisoformat 带偏移)→ 原样保留。
+    - tz_offset_minutes 为 None(老客户端未传)→ 退回旧行为:当作 UTC,不破坏兼容。
+    """
+    if dt.tzinfo is not None:
+        return dt
+    if tz_offset_minutes is None:
+        return dt.replace(tzinfo=timezone.utc)
+    local_tz = timezone(timedelta(minutes=tz_offset_minutes))
+    return dt.replace(tzinfo=local_tz).astimezone(timezone.utc)
+
+
+def _parse_datetime(
+    raw: str, fmt: str | None, tz_offset_minutes: int | None = None
+) -> datetime | None:
     s = raw.strip()
     if not s:
         return None
     if fmt:
         try:
-            dt = datetime.strptime(s, fmt)
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            return dt
+            return _localize_naive(datetime.strptime(s, fmt), tz_offset_minutes)
         except ValueError:
             return None
     # auto try
     for f in _DATETIME_CANDIDATES:
         try:
-            dt = datetime.strptime(s, f)
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            return dt
+            return _localize_naive(datetime.strptime(s, f), tz_offset_minutes)
         except ValueError:
             continue
     # 最后兜底:fromisoformat 容忍多种 ISO 变体
     try:
         s2 = s.replace("Z", "+00:00")
-        dt = datetime.fromisoformat(s2)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return dt
+        return _localize_naive(datetime.fromisoformat(s2), tz_offset_minutes)
     except ValueError:
         return None
 

--- a/tests/test_import_csv.py
+++ b/tests/test_import_csv.py
@@ -182,6 +182,30 @@ def test_apply_mapping_required_field_missing():
     assert txs == []
 
 
+def test_apply_mapping_tz_offset_local_to_utc():
+    """issue #314: CSV 里是用户本地墙钟,应按客户端时区 offset 换算成 UTC,
+    而不是直接当 UTC(否则 UTC+8 用户导入后会整体晚 8 小时)。"""
+    csv = "类型,金额,时间,分类\n支出,35.00,2024-08-29 23:16,餐饮\n"
+    data = parse_csv_text(raw_text=csv)
+    mapping = data.suggested_mapping
+    mapping.tz_offset_minutes = 480  # UTC+8(北京)
+    txs, errors, _ = apply_mapping(rows=data.rows, mapping=mapping)
+    assert errors == []
+    # 23:16 北京时间 == 15:16 UTC
+    assert txs[0].happened_at == datetime(2024, 8, 29, 15, 16, tzinfo=timezone.utc)
+
+
+def test_apply_mapping_tz_offset_none_keeps_utc():
+    """未传 tz_offset(老客户端)→ 保持旧行为:naive 当 UTC,向后兼容不破坏。"""
+    csv = "类型,金额,时间,分类\n支出,35.00,2024-08-29 23:16,餐饮\n"
+    data = parse_csv_text(raw_text=csv)
+    mapping = data.suggested_mapping
+    assert mapping.tz_offset_minutes is None
+    txs, errors, _ = apply_mapping(rows=data.rows, mapping=mapping)
+    assert errors == []
+    assert txs[0].happened_at == datetime(2024, 8, 29, 23, 16, tzinfo=timezone.utc)
+
+
 def test_apply_mapping_user_override():
     """generic parser 没识别 tx_type 时,用户手填映射应该工作。"""
     csv = "状态,金额,时间,分类\n支出,35,2024-05-01,餐饮\n"

--- a/tests/test_import_csv.py
+++ b/tests/test_import_csv.py
@@ -334,6 +334,31 @@ def test_upload_and_preview_happy_path():
         app.dependency_overrides.clear()
 
 
+def test_upload_with_tz_offset_localizes_happened_at():
+    """issue #314: upload 带 tz_offset_minutes 时,CSV 本地时间应换算成正确 UTC,
+    而非直接当 UTC(否则返回的 sample_transactions / 之后 execute 全偏 +8h)。"""
+    client = _make_client()
+    try:
+        token = _login(client, "imptz@test.com")
+        ledger_id = _make_ledger(client, token)
+        csv = "类型,分类,金额,账户,时间\n支出,彩票,819.19,工行,2026-05-23 21:28:52\n"
+        files = {"file": ("t.csv", csv.encode("utf-8"), "text/csv")}
+        r = client.post(
+            "/api/v1/import/upload",
+            files=files,
+            data={"target_ledger_id": ledger_id, "tz_offset_minutes": "480"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200, r.text
+        ts = r.json()["sample_transactions"][0]["happened_at"]
+        # 21:28:52 北京(UTC+8)== 13:28:52 UTC;修复前会是 "2026-05-23T21:28:52+00:00"
+        assert datetime.fromisoformat(ts) == datetime(
+            2026, 5, 23, 13, 28, 52, tzinfo=timezone.utc
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+
 def test_preview_recompute_when_target_ledger_changes():
     client = _make_client()
     try:


### PR DESCRIPTION
## 问题

服务端「从 BeeCount Cloud 导入数据」(CSV/Excel)把单元格里的**本地时间**(naive datetime)直接当 UTC 存储——`_parse_datetime` 里 `replace(tzinfo=timezone.utc)`。UTC+8 用户导入后,交易时间被下游 `_to_iso_utc` 当 UTC 发给客户端,客户端 `toLocal()` 后**整体晚 8 小时**。

移动端 app 同步发的是带 `Z` 的 UTC,不受影响——所以问题只在云端导入这条链路。

## 修复

- 前端 `previewImport` 时自动带上浏览器时区偏移 `tz_offset_minutes`(东为正,UTC+8 = `-new Date().getTimezoneOffset()` = 480)。
- 后端 `_parse_datetime` 新增 `_localize_naive`:把 naive 墙钟按该偏移视为本地时间再换算成 UTC。
- **向后兼容**:`tz_offset_minutes` 为 `None`(老客户端未传)时退回旧行为(当作 UTC),不破坏既有数据流。

## 测试

`tests/test_import_csv.py` 新增两例:
- `test_apply_mapping_tz_offset_local_to_utc`:`2024-08-29 23:16` + offset 480 → `15:16Z` ✓
- `test_apply_mapping_tz_offset_none_keeps_utc`:不传 offset → 维持 `23:16Z`(兼容)✓

全量 `test_import_csv.py`(23 例)通过。

关联 TNT-Likely/BeeCount#314
