### PR TITLE
fix: 资产统计负债符号口径对齐 App(修溢缴款反向扣减)

### DIFF
--- a/frontend/apps/web/src/assetAggregation.test.ts
+++ b/frontend/apps/web/src/assetAggregation.test.ts
@@ -4,7 +4,6 @@ import {
   type AssetGroup,
   computeCurrencySummary,
   effectiveRateToBase,
-  LIABILITY_TYPES,
   mergeGroupsToBase,
   splitByCurrency
 } from '@beecount/web-features'
@@ -41,16 +40,37 @@ describe('asset aggregation — 绝不跨币种相加', () => {
     expect(accountBalance(acc({}))).toBe(0)
   })
 
-  it('computeCurrencySummary:资产保留符号、负债按 |balance| 计欠款', () => {
+  it('computeCurrencySummary:资产负债都带符号,净值 = 资产 + 负债(对齐 mobile getNetWorthBreakdown)', () => {
     const s = computeCurrencySummary([
       acc({ account_type: 'cash', balance: 1000 }),
       acc({ account_type: 'bank_card', balance: -200 }), // 透支资产 → 扣减总资产
-      acc({ account_type: 'credit_card', balance: -300 }), // 负债
+      acc({ account_type: 'credit_card', balance: -300 }), // 负债(欠款为负)
       acc({ account_type: 'loan', balance: -500 }) // 负债
     ])
     expect(s.assetTotal).toBe(800) // 1000 + (-200)
-    expect(s.liabilityTotal).toBe(800) // |−300| + |−500|
-    expect(s.netWorth).toBe(0) // 800 − 800
+    expect(s.liabilityTotal).toBe(-800) // 带符号:−300 + −500,展示欠款时才 abs
+    expect(s.netWorth).toBe(0) // 800 + (−800)
+  })
+
+  it('溢缴款:负债账户正余额**增加**净值,绝不反向当欠款扣减(历史 bug:abs 后减)', () => {
+    // 复盘场景:脏数据把 76 万收入灌进信用卡,余额 +761779.84。app 端净资产
+    // 正确地 +76 万,web 端旧逻辑 abs 后减、又扣 76 万,两端差 152 万。
+    const s = computeCurrencySummary([
+      acc({ account_type: 'cash', balance: 1_000_000 }),
+      acc({ account_type: 'credit_card', balance: 761_779.84 }) // 溢缴/正余额负债
+    ])
+    expect(s.liabilityTotal).toBe(761_779.84)
+    expect(s.netWorth).toBeCloseTo(1_761_779.84, 2) // 加上,而不是 1_000_000 − 761_779.84
+  })
+
+  it('负债内部正负互抵:+10w 信用卡 + −20w 贷款 → 合计 −10w(展示欠 10w,而非逐账户 abs 的 30w)', () => {
+    const s = computeCurrencySummary([
+      acc({ account_type: 'credit_card', balance: 100_000 }),
+      acc({ account_type: 'loan', balance: -200_000 })
+    ])
+    expect(s.liabilityTotal).toBe(-100_000)
+    expect(Math.abs(s.liabilityTotal)).toBe(100_000) // 展示层口径
+    expect(s.netWorth).toBe(-100_000)
   })
 
   it('每币种汇总各自独立 —— CNY 与 USD 不合并', () => {
@@ -65,14 +85,11 @@ describe('asset aggregation — 绝不跨币种相加', () => {
 
     expect(cny.netWorth).toBe(2_472_500)
     expect(usd.assetTotal).toBe(1200)
-    expect(usd.liabilityTotal).toBe(300)
+    expect(usd.liabilityTotal).toBe(-300)
     expect(usd.netWorth).toBe(900)
 
     // 反例:旧 bug 的裸加会把 $ 当 ¥ 得到 2_473_400 这种错值。分币种后绝不会出现。
-    const naiveWrong = rows.reduce((sum, r) => {
-      const raw = accountBalance(r)
-      return sum + (LIABILITY_TYPES.has(r.account_type || '') ? -Math.abs(raw) : raw)
-    }, 0)
+    const naiveWrong = rows.reduce((sum, r) => sum + accountBalance(r), 0)
     expect(naiveWrong).toBe(2_473_400)
     expect(cny.netWorth).not.toBe(naiveWrong)
   })

--- a/frontend/apps/web/src/components/dashboard/AssetCompositionDonut.tsx
+++ b/frontend/apps/web/src/components/dashboard/AssetCompositionDonut.tsx
@@ -24,6 +24,9 @@ const TYPE_META: Record<string, { color: string; group: 'asset' | 'liability' }>
 
 export function AssetCompositionDonut({ accounts }: Props) {
   const t = useT()
+  // 按类型**带符号**累加(与 assetAggregation 的负债符号口径一致:欠款为负、
+  // 溢缴为正,透支资产为负),饼图分段才对类型合计取 abs 当体量 —— 绝不逐账户
+  // abs,否则同类型内正负互抵的账户会被虚增。
   const totals = new Map<string, number>()
   for (const a of accounts) {
     const key = a.account_type || 'other'
@@ -33,13 +36,13 @@ export function AssetCompositionDonut({ accounts }: Props) {
     const raw = typeof a.balance === 'number' && a.balance !== null
       ? a.balance
       : a.initial_balance ?? 0
-    const amount = Math.abs(raw)
-    totals.set(key, (totals.get(key) || 0) + amount)
+    totals.set(key, (totals.get(key) || 0) + raw)
   }
   const data = Array.from(totals.entries())
-    .map(([type, value]) => ({
+    .map(([type, signed]) => ({
       type,
-      value,
+      signed,
+      value: Math.abs(signed),
       label: TYPE_META[type] ? t(`accountType.${type}` as never) : type,
       color: TYPE_META[type]?.color || '#94a3b8',
       group: TYPE_META[type]?.group || 'asset'
@@ -47,8 +50,11 @@ export function AssetCompositionDonut({ accounts }: Props) {
     .filter((d) => d.value > 0)
     .sort((a, b) => b.value - a.value)
 
-  const totalAsset = data.filter((d) => d.group === 'asset').reduce((s, d) => s + d.value, 0)
-  const totalLiability = data.filter((d) => d.group === 'liability').reduce((s, d) => s + d.value, 0)
+  // 中心数字与 App 口径一致:总资产 = 资产类带符号合计;负债脚注 = |负债类带符号合计|。
+  const totalAsset = data.filter((d) => d.group === 'asset').reduce((s, d) => s + d.signed, 0)
+  const totalLiability = Math.abs(
+    data.filter((d) => d.group === 'liability').reduce((s, d) => s + d.signed, 0)
+  )
 
   const fmt = (v: number) =>
     v.toLocaleString('zh-CN', { minimumFractionDigits: 0, maximumFractionDigits: 2 })

--- a/frontend/apps/web/src/components/dashboard/OverviewHero.tsx
+++ b/frontend/apps/web/src/components/dashboard/OverviewHero.tsx
@@ -1,6 +1,7 @@
 import { Area, AreaChart, ResponsiveContainer, Tooltip } from 'recharts'
 import type { ReadAccount, ReadLedger } from '@beecount/api-client'
 import { useT } from '@beecount/ui'
+import { accountBalance } from '@beecount/web-features'
 
 interface Props {
   ledgers: ReadLedger[]
@@ -18,14 +19,13 @@ function currencyLabel(ledgers: ReadLedger[]): string {
   return first?.currency || 'CNY'
 }
 
-// 负债类账户（信用卡、贷款）计入负债，其余全算资产。与 AccountsPanel 的
-// VALUATION_TYPES + LIABILITY_TYPES 保持一致。
-const LIABILITY_TYPES = new Set(['credit_card', 'loan'])
-
 /**
- * Hero 横幅：净值 = 资产 - 负债（按账户余额聚合）+ 周期收支副标题 + 右侧
- * 迷你 sparkline。之前用 ledger.balance 汇总 (收入-支出) 做"净资产"实际是
- * 现金流净额，和"资产-负债"不是一回事，数字跟下方资产环形图对不上。
+ * Hero 横幅：净值 = Σ 账户带符号余额（复用 assetAggregation 的负债符号口径单点：
+ * 欠款为负自然扣减、溢缴为正计入）+ 周期收支副标题 + 右侧迷你 sparkline。
+ * 之前这里手搓了一份聚合：资产负债全取 `Math.abs(initial_balance)` 再相减 ——
+ * 既丢了符号（透支/溢缴全算错）也没吃 server 聚合后的 balance，跟资产页对不上。
+ * 已知债：这里仍把所有账户裸加（未按币种切分），多币种用户的 hero 净值口径
+ * 留待多币种 dashboard 折算一并解决，不在负债符号修复范围内。
  */
 export function OverviewHero({
   ledgers,
@@ -37,17 +37,7 @@ export function OverviewHero({
   const t = useT()
   const scopeLabel = periodLabel ?? t('home.scope.year')
   const currency = currencyLabel(ledgers)
-  let assetTotal = 0
-  let liabilityTotal = 0
-  for (const a of accounts || []) {
-    const bal = Math.abs(a.initial_balance ?? 0)
-    if (LIABILITY_TYPES.has(a.account_type || '')) {
-      liabilityTotal += bal
-    } else {
-      assetTotal += bal
-    }
-  }
-  const totalBalance = assetTotal - liabilityTotal
+  const totalBalance = (accounts || []).reduce((sum, a) => sum + accountBalance(a), 0)
   // 优先吃后端给的 summary（无论 series 空不空都是权威值）；fallback 到 series 聚合。
   const periodIncome =
     periodSummary?.income_total ??

--- a/frontend/apps/web/src/pages/sections/AccountsPage.tsx
+++ b/frontend/apps/web/src/pages/sections/AccountsPage.tsx
@@ -325,8 +325,8 @@ export function AccountsPage() {
       buckets: buckets.sort(
         (a, b) =>
           b.summary.assetTotal +
-          b.summary.liabilityTotal -
-          (a.summary.assetTotal + a.summary.liabilityTotal),
+          Math.abs(b.summary.liabilityTotal) -
+          (a.summary.assetTotal + Math.abs(a.summary.liabilityTotal)),
       ),
       missing: [...missing].sort(),
       rateDate: rates?.rate_date,
@@ -393,7 +393,7 @@ export function AccountsPage() {
                   <div className="mt-0.5 flex items-baseline gap-1">
                     <span className="font-mono text-xs text-muted-foreground">≈</span>
                     <Amount
-                      value={converted.liabilityTotal}
+                      value={Math.abs(converted.liabilityTotal)}
                       currency={base}
                       size="lg"
                       bold
@@ -408,7 +408,7 @@ export function AccountsPage() {
               {converted.mergedGroups.length > 0 ? (
                 <AssetsCompositionMini
                   groups={converted.mergedGroups}
-                  totalAbs={converted.assetTotal + converted.liabilityTotal}
+                  totalAbs={converted.assetTotal + Math.abs(converted.liabilityTotal)}
                   currency={base}
                   showCurrency
                   embedded

--- a/frontend/packages/web-features/src/features/AccountsPanel.tsx
+++ b/frontend/packages/web-features/src/features/AccountsPanel.tsx
@@ -100,7 +100,7 @@ function MobileStyleAssets({
           <AssetsSummaryHero summary={single.summary} currency={single.currency} />
           <AssetsCompositionMini
             groups={single.groups}
-            totalAbs={single.summary.assetTotal + single.summary.liabilityTotal}
+            totalAbs={single.summary.assetTotal + Math.abs(single.summary.liabilityTotal)}
             currency={single.currency}
           />
         </div>
@@ -164,7 +164,7 @@ function MobileStyleAssets({
                     {group.subtotals.map((st) => (
                       <Amount
                         key={st.currency}
-                        value={st.value}
+                        value={group.isLiability ? Math.abs(st.value) : st.value}
                         currency={st.currency}
                         showCurrency={multiCurrency}
                         size={group.subtotals.length > 1 ? 'md' : 'xl'}
@@ -262,7 +262,7 @@ function AssetsSummaryHero({
               {t('accounts.liabilities')}
             </div>
             <Amount
-              value={summary.liabilityTotal}
+              value={Math.abs(summary.liabilityTotal)}
               currency={currency}
               size="xl"
               bold
@@ -304,11 +304,12 @@ export function AssetsCompositionMini({
 }) {
   const t = useT()
   // 传进来的 groups 一定是单币种(单币种页 or 某一币种卡),subtotals 求和即该币种值。
+  // 小计带符号(负债欠款为负),饼图分段要的是体量 —— 对组合计取 abs。
   const data = groups.map((g) => ({
     type: g.type,
     label: g.label,
     color: g.color,
-    value: g.subtotals.reduce((s, x) => s + x.value, 0)
+    value: Math.abs(g.subtotals.reduce((s, x) => s + x.value, 0))
   }))
   const total = totalAbs > 0 ? totalAbs : 1
   // conic-gradient 分段
@@ -780,11 +781,13 @@ export function computeTypeGroups(rows: ReadAccount[], t: (k: string) => string)
   return ACCOUNT_ORDER.filter((type) => (buckets[type] || []).length > 0).map((type) => {
     const groupRows = (buckets[type] || []).slice().sort((a, b) => a.name.localeCompare(b.name))
     const isLiability = LIABILITY_TYPES.has(type)
+    // 小计带符号累加(与 computeCurrencySummary 同口径)——溢缴的卡会抵销欠款。
+    // 展示"共欠"时由渲染处对组合计取 abs,绝不逐账户 abs(否则 +10w 卡 + −20w 贷
+    // 会显示成欠 30w)。
     const byCur = new Map<string, number>()
     for (const r of groupRows) {
       const cur = (r.currency || 'CNY').toUpperCase()
-      const raw = accountBalance(r)
-      byCur.set(cur, (byCur.get(cur) ?? 0) + (isLiability ? Math.abs(raw) : raw))
+      byCur.set(cur, (byCur.get(cur) ?? 0) + accountBalance(r))
     }
     return {
       type,
@@ -804,7 +807,7 @@ export function computeTypeGroups(rows: ReadAccount[], t: (k: string) => string)
 export function CurrencyAssetCard({ entry }: { entry: CurrencyBucket }) {
   const t = useT()
   const { currency, summary, groups } = entry
-  const totalAbs = summary.assetTotal + summary.liabilityTotal
+  const totalAbs = summary.assetTotal + Math.abs(summary.liabilityTotal)
   return (
     <div className="flex flex-col overflow-hidden rounded-2xl border border-border/50 bg-card/60">
       <div className="flex items-center justify-between gap-2 border-b border-border/40 px-4 py-3">
@@ -846,7 +849,7 @@ export function CurrencyAssetCard({ entry }: { entry: CurrencyBucket }) {
             {t('accounts.liabilities')}
           </div>
           <Amount
-            value={summary.liabilityTotal}
+            value={Math.abs(summary.liabilityTotal)}
             currency={currency}
             showCurrency
             size="md"
@@ -908,12 +911,12 @@ export function AccountsPanel({
         summary: computeCurrencySummary(curRows),
         groups: computeTypeGroups(curRows, t)
       }))
-      // 体量大的币种排前面(资产+负债绝对额)
+      // 体量大的币种排前面(资产 + |负债|)
       .sort(
         (a, b) =>
           b.summary.assetTotal +
-          b.summary.liabilityTotal -
-          (a.summary.assetTotal + a.summary.liabilityTotal)
+          Math.abs(b.summary.liabilityTotal) -
+          (a.summary.assetTotal + Math.abs(a.summary.liabilityTotal))
       )
   }, [rows, t])
 

--- a/frontend/packages/web-features/src/lib/assetAggregation.ts
+++ b/frontend/packages/web-features/src/lib/assetAggregation.ts
@@ -11,6 +11,7 @@ import type { ExchangeRateOverride, ExchangeRatesResponse, ReadAccount } from '@
 
 export type AssetSummary = {
   assetTotal: number
+  /** 带符号:欠款为负、溢缴为正。展示"总负债"时取 Math.abs,绝不在聚合层提前 abs。 */
   liabilityTotal: number
   netWorth: number
 }
@@ -29,7 +30,7 @@ export type AssetGroup = {
   subtotals: { currency: string; value: number }[]
 }
 
-/** 负债类账户类型:余额按 |balance| 计欠款,从净值里扣减。 */
+/** 负债类账户类型:余额带符号计入净值(欠款为负扣减、溢缴为正增加),展示欠款时才取 abs。 */
 export const LIABILITY_TYPES = new Set(['credit_card', 'loan'])
 
 /** 账户展示余额:优先 server 聚合后的 balance(含所有交易),否则回退 initial_balance。 */
@@ -56,8 +57,11 @@ export function splitByCurrency(rows: ReadAccount[]): Map<string, ReadAccount[]>
 }
 
 /**
- * 单币种净值汇总。负债类按 |balance| 累计欠款,资产类保留符号(透支账户 balance<0
- * 会扣减总资产),跟 mobile `local_account_repository.getNetWorthBreakdown` 口径一致。
+ * 单币种净值汇总。资产、负债都**带符号**累加,净值 = 资产 + 负债,跟 mobile
+ * `local_account_repository.getNetWorthBreakdown` 口径一致:负债账户余额通常为负
+ * (欠款,扣减净值),为正表示溢缴款(还多了的钱,经济上是资产头寸,增加净值)。
+ * 历史教训:这里曾逐账户 `Math.abs` 再做减法,正常数据(欠款为负)下结果碰巧相同,
+ * 直到溢缴/正余额负债账户出现才暴露 —— 把多打进去的钱又反向当欠款扣了一遍。
  *
  * 入参**必须是同一币种**的账户(由 {@link splitByCurrency} 保证)—— 传混币种进来
  * 得到的就是那个错的合并数字,这正是本模块要避免的。
@@ -67,10 +71,10 @@ export function computeCurrencySummary(rows: ReadAccount[]): AssetSummary {
   let liabilityTotal = 0
   for (const row of rows) {
     const raw = accountBalance(row)
-    if (LIABILITY_TYPES.has(row.account_type || '')) liabilityTotal += Math.abs(raw)
+    if (LIABILITY_TYPES.has(row.account_type || '')) liabilityTotal += raw
     else assetTotal += raw
   }
-  return { assetTotal, liabilityTotal, netWorth: assetTotal - liabilityTotal }
+  return { assetTotal, liabilityTotal, netWorth: assetTotal + liabilityTotal }
 }
 
 /** 有效汇率:override(1 quote = x base)优先;否则代理自动值(1 base = x quote)取倒数。缺失返回 null,绝不回落 1。 */


### PR DESCRIPTION
## 背景

导入测试数据后 App 与 Web 资产页净资产相差 152 万:一个负债账户(信用卡)被灌入大额收入后余额为正(+76 万),App 净资产**加**了这 76 万,Web **减**了。App 口径正确:负债账户正余额=溢缴款,经济上是资产头寸。该 bug 在真实数据(多还信用卡产生溢缴)下同样会出现。

## 修复(对齐 mobile getNetWorthBreakdown 口径)

- `assetAggregation.ts` `computeCurrencySummary`:负债**带符号**累加,`netWorth = assetTotal + liabilityTotal`(原来逐账户 `Math.abs` 后做减法,正常数据下结果碰巧相同所以一直没暴露)
- 展示层统一"对**合计**取 abs,绝不逐账户 abs"(否则 +10w 卡 + −20w 贷会显示欠 30w):AccountsPanel 分组小计/净值卡/币种卡、AccountsPage 折算汇总、AssetCompositionDonut
- `OverviewHero`:手搓聚合(资产负债全 `Math.abs(initial_balance)` 相减)改为复用 `accountBalance` 带符号求和,并吃上 server 聚合 balance
- 测试按新契约重写,新增溢缴款用例(+761,779.84 → 净值加上)与负债正负互抵用例

## 验证

- vitest 48/48 通过,`tsc -b && vite build` 通过
- App 端配套:demo 生成器已修(BeeCount 仓),重导数据后两端三数应完全一致