### PR TITLE
feat: 交易账单标记(不计入收支/不计入预算)服务端 + Web

### DIFF
--- a/alembic/versions/0017_transaction_exclude_flags.py
+++ b/alembic/versions/0017_transaction_exclude_flags.py
@@ -1,0 +1,31 @@
+"""交易标记:read_tx_projection.exclude_from_stats / exclude_from_budget
+
+Revision ID: 0017_transaction_exclude_flags
+Revises: 0016_multi_currency
+Create Date: 2026-06-18
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0017_transaction_exclude_flags"
+down_revision = "0016_multi_currency"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "read_tx_projection",
+        sa.Column("exclude_from_stats", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "read_tx_projection",
+        sa.Column("exclude_from_budget", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("read_tx_projection", "exclude_from_budget")
+    op.drop_column("read_tx_projection", "exclude_from_stats")

--- a/frontend/apps/web/src/components/GlobalEditDialogs.tsx
+++ b/frontend/apps/web/src/components/GlobalEditDialogs.tsx
@@ -134,6 +134,8 @@ export function GlobalEditDialogs() {
                 .map((s) => s.trim())
                 .filter((s) => s.length > 0),
         attachments: Array.isArray(tx.attachments) ? tx.attachments : [],
+        exclude_from_stats: Boolean(tx.exclude_from_stats),
+        exclude_from_budget: Boolean(tx.exclude_from_budget),
       })
       // 等 refs 拉完再打开 dialog,确保 category/account/tag 下拉有数据
       await loadRefsForLedger(ledgerId)
@@ -231,6 +233,11 @@ export function GlobalEditDialogs() {
           : null,
       tags: editTxForm.tags.filter((s) => s.length > 0),
       attachments: editTxForm.attachments,
+      // §三 标记按 type 条件落库:转账两者都置 false;收入只允许 stats;支出两者都允许。
+      exclude_from_stats:
+        editTxForm.tx_type === 'transfer' ? false : editTxForm.exclude_from_stats,
+      exclude_from_budget:
+        editTxForm.tx_type === 'expense' ? editTxForm.exclude_from_budget : false,
     }
 
     try {

--- a/frontend/apps/web/src/i18n/en.ts
+++ b/frontend/apps/web/src/i18n/en.ts
@@ -1059,6 +1059,11 @@ const en = {
   'transactions.placeholder.fromAccountName': 'from_account_name',
   'transactions.placeholder.toAccountName': 'to_account_name',
   'transactions.placeholder.tags': 'Select tags',
+  // 账单标记(per-transaction flags,issue #340 / .docs/transaction-flags)
+  txFlagExcludeFromStats: 'Exclude from income/expense',
+  txFlagExcludeFromBudget: 'Exclude from budget',
+  txFlagExcludedTag: 'Excluded',
+  txFlagBudgetExcludedTag: 'No budget',
   'transactions.dictionary.loading': 'Loading selectable data...',
   'transactions.button.create': 'Create Tx',
   'transactions.button.update': 'Update Tx',

--- a/frontend/apps/web/src/i18n/zh-CN.ts
+++ b/frontend/apps/web/src/i18n/zh-CN.ts
@@ -1101,6 +1101,11 @@ const zhCN = {
   'transactions.placeholder.fromAccountName': '转出账户',
   'transactions.placeholder.toAccountName': '转入账户',
   'transactions.placeholder.tags': '选择标签',
+  // 账单标记(per-transaction flags,issue #340 / .docs/transaction-flags)
+  txFlagExcludeFromStats: '不计入收支',
+  txFlagExcludeFromBudget: '不计入预算',
+  txFlagExcludedTag: '不计收支',
+  txFlagBudgetExcludedTag: '不计预算',
   'transactions.dictionary.loading': '正在加载可选数据...',
   'transactions.button.create': '新建交易',
   'transactions.button.update': '更新交易',

--- a/frontend/apps/web/src/i18n/zh-TW.ts
+++ b/frontend/apps/web/src/i18n/zh-TW.ts
@@ -1060,6 +1060,11 @@ const zhTW = {
   'transactions.placeholder.fromAccountName': '轉出帳戶',
   'transactions.placeholder.toAccountName': '轉入帳戶',
   'transactions.placeholder.tags': '選擇標籤',
+  // 帳單標記(per-transaction flags,issue #340 / .docs/transaction-flags)
+  txFlagExcludeFromStats: '不計入收支',
+  txFlagExcludeFromBudget: '不計入預算',
+  txFlagExcludedTag: '不計收支',
+  txFlagBudgetExcludedTag: '不計預算',
   'transactions.dictionary.loading': '正在載入可選資料...',
   'transactions.button.create': '建立交易',
   'transactions.button.update': '更新交易',

--- a/frontend/apps/web/src/pages/sections/TransactionsPage.tsx
+++ b/frontend/apps/web/src/pages/sections/TransactionsPage.tsx
@@ -1428,7 +1428,10 @@ export function TransactionsPage() {
         to_account_id: isTransfer ? accountByName.get(toAccountName.toLowerCase()) || null : null,
         tags: txForm.tags.length > 0 ? txForm.tags : null,
         tag_ids: txTagIds.length > 0 ? txTagIds : null,
-        attachments: txForm.attachments.length > 0 ? txForm.attachments : null
+        attachments: txForm.attachments.length > 0 ? txForm.attachments : null,
+        // §三 标记按 type 条件落库:转账两者都 false;收入只允许 stats;支出两者都允许。
+        exclude_from_stats: isTransfer ? false : txForm.exclude_from_stats,
+        exclude_from_budget: txForm.tx_type === 'expense' ? txForm.exclude_from_budget : false
       }
       // eslint-disable-next-line no-console
       console.info('[tx-save] request', {
@@ -1939,7 +1942,9 @@ export function TransactionsPage() {
                             .split(',')
                             .map((value) => value.trim())
                             .filter((value) => value.length > 0),
-                    attachments: normalizeAttachmentRefs(tx.attachments)
+                    attachments: normalizeAttachmentRefs(tx.attachments),
+                    exclude_from_stats: Boolean(tx.exclude_from_stats),
+                    exclude_from_budget: Boolean(tx.exclude_from_budget)
                   })
                 }}
                 onDelete={(row) =>

--- a/frontend/packages/api-client/src/types.ts
+++ b/frontend/packages/api-client/src/types.ts
@@ -179,6 +179,10 @@ export type ReadTransaction = {
   tags_list: string[]
   tag_ids?: string[]
   attachments: AttachmentRef[] | null
+  /** 不计入收支统计(仍计入账户余额/净资产)。历史交易默认 false。 */
+  exclude_from_stats?: boolean
+  /** 不计入预算用量(仅 expense 有意义)。历史交易默认 false。 */
+  exclude_from_budget?: boolean
   last_change_id: number
   ledger_id?: string | null
   ledger_name?: string | null
@@ -544,6 +548,10 @@ export type TxPayload = {
   tags?: string | string[] | null
   tag_ids?: string[] | null
   attachments?: AttachmentRef[] | null
+  /** 不计入收支统计(income/expense 可填,transfer 无意义)。 */
+  exclude_from_stats?: boolean | null
+  /** 不计入预算用量(仅 expense 有意义)。 */
+  exclude_from_budget?: boolean | null
 }
 
 export type BudgetCreatePayload = {

--- a/frontend/packages/web-features/src/components/TransactionRow.tsx
+++ b/frontend/packages/web-features/src/components/TransactionRow.tsx
@@ -280,6 +280,13 @@ export function TransactionRow({
               <span className="font-mono tabular-nums">{attachments.length}</span>
             </button>
           ) : null}
+          {/* §4.2 标记小灰字 — 不改金额、不加图标,只在第二排尾部追加灰字标签 */}
+          {row.exclude_from_stats ? (
+            <span>· {t('txFlagExcludedTag')}</span>
+          ) : null}
+          {row.exclude_from_budget ? (
+            <span>· {t('txFlagBudgetExcludedTag')}</span>
+          ) : null}
         </div>
 
         {/* 右下:创建/编辑头像 chip — self-end 钉到 row 底部,跟左下 meta

--- a/frontend/packages/web-features/src/features/TransactionsPanel.tsx
+++ b/frontend/packages/web-features/src/features/TransactionsPanel.tsx
@@ -320,12 +320,15 @@ export function TransactionsPanel({
 
   const applyTxType = (nextType: TxForm['tx_type']) => {
     if (nextType === 'transfer') {
+      // 转账两个标记都隐藏 → 清掉,避免残留脏值
       onFormChange({
         ...form,
         tx_type: nextType,
         account_name: '',
         category_name: '',
-        category_kind: 'transfer'
+        category_kind: 'transfer',
+        exclude_from_stats: false,
+        exclude_from_budget: false
       })
       return
     }
@@ -336,7 +339,9 @@ export function TransactionsPanel({
       category_kind: nextType,
       category_name: keepCategory,
       from_account_name: '',
-      to_account_name: ''
+      to_account_name: '',
+      // 不计入预算仅 expense 显示;切到 income 时清掉
+      exclude_from_budget: nextType === 'expense' ? form.exclude_from_budget : false
     })
   }
 
@@ -597,6 +602,55 @@ export function TransactionsPanel({
                 onChange={(e) => onFormChange({ ...form, note: e.target.value })}
               />
             </div>
+            {/* §三 标记开关 — 按当前 type 条件显示:
+                  不计入收支:income / expense(转账本就不进收支,隐藏)
+                  不计入预算:仅 expense(预算只统计支出) */}
+            {form.tx_type !== 'transfer' ? (
+              <div className="flex items-center justify-between rounded-lg border border-border/60 bg-muted/20 px-3 py-2 md:col-span-2">
+                <p className="text-sm font-medium">{t('txFlagExcludeFromStats')}</p>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={form.exclude_from_stats}
+                  aria-label={t('txFlagExcludeFromStats') as string}
+                  onClick={() =>
+                    onFormChange({ ...form, exclude_from_stats: !form.exclude_from_stats })
+                  }
+                  className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors ${
+                    form.exclude_from_stats ? 'bg-primary' : 'bg-muted-foreground/30'
+                  }`}
+                >
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                      form.exclude_from_stats ? 'translate-x-[18px]' : 'translate-x-0.5'
+                    }`}
+                  />
+                </button>
+              </div>
+            ) : null}
+            {form.tx_type === 'expense' ? (
+              <div className="flex items-center justify-between rounded-lg border border-border/60 bg-muted/20 px-3 py-2 md:col-span-2">
+                <p className="text-sm font-medium">{t('txFlagExcludeFromBudget')}</p>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={form.exclude_from_budget}
+                  aria-label={t('txFlagExcludeFromBudget') as string}
+                  onClick={() =>
+                    onFormChange({ ...form, exclude_from_budget: !form.exclude_from_budget })
+                  }
+                  className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors ${
+                    form.exclude_from_budget ? 'bg-primary' : 'bg-muted-foreground/30'
+                  }`}
+                >
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                      form.exclude_from_budget ? 'translate-x-[18px]' : 'translate-x-0.5'
+                    }`}
+                  />
+                </button>
+              </div>
+            ) : null}
           </div>
           </div>
           <DialogFooter className="shrink-0 border-t border-border/60 bg-card px-6 py-4">

--- a/frontend/packages/web-features/src/forms.ts
+++ b/frontend/packages/web-features/src/forms.ts
@@ -14,6 +14,10 @@ export type TxForm = {
   to_account_name: string
   tags: string[]
   attachments: AttachmentRef[]
+  /** 不计入收支统计(income/expense 显示开关,transfer 隐藏)。 */
+  exclude_from_stats: boolean
+  /** 不计入预算用量(仅 expense 显示开关)。 */
+  exclude_from_budget: boolean
 }
 
 export type AccountForm = {
@@ -92,7 +96,9 @@ export const txDefaults = (): TxForm => ({
   from_account_name: '',
   to_account_name: '',
   tags: [],
-  attachments: []
+  attachments: [],
+  exclude_from_stats: false,
+  exclude_from_budget: false
 })
 
 export const accountDefaults = (): AccountForm => ({

--- a/src/models.py
+++ b/src/models.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    false,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -497,6 +498,15 @@ class ReadTxProjection(Base):
     created_by_user_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
     last_edited_by_user_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
     source_change_id: Mapped[int] = mapped_column(BigInteger, default=0)
+    # 账单标记(.docs/transaction-flags)。default false:既有行升级后不过滤,
+    # 旧 App 不发该字段时保持 false。exclude_from_stats=不计入收支统计;
+    # exclude_from_budget=不计入预算用量。两者独立。
+    exclude_from_stats: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=false(), default=False
+    )
+    exclude_from_budget: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=false(), default=False
+    )
 
 
 Index(

--- a/src/projection.py
+++ b/src/projection.py
@@ -250,6 +250,10 @@ def upsert_tx(
         # 共享账本 Phase 1:每次 upsert 都更新 last_edited_by_user_id;
         # payload 没带就回退 created。
         "last_edited_by_user_id": _as_str(payload.get("updatedByUserId")) or payload_creator,
+        # 账单标记(.docs/transaction-flags)。缺键保留由上游 merge_with_existing
+        # 负责(payload 已含既有行值),这里只做布尔强转;default=False 兜底首次插入。
+        "exclude_from_stats": _as_bool(payload.get("excludeFromStats"), default=False),
+        "exclude_from_budget": _as_bool(payload.get("excludeFromBudget"), default=False),
         "source_change_id": source_change_id,
     }
 

--- a/src/routers/read/ledgers.py
+++ b/src/routers/read/ledgers.py
@@ -4,6 +4,8 @@
 都是以账本为主键的 projection 查询,不做跨账本聚合。"""
 from __future__ import annotations
 
+from sqlalchemy import false as sa_false
+
 from ._shared import *  # noqa: F401,F403 — imports + helpers + router
 
 
@@ -580,6 +582,9 @@ def list_budgets_usage(
             ReadTxProjection.tx_type == "expense",
             ReadTxProjection.happened_at >= start,
             ReadTxProjection.happened_at < end,
+            # D2: 预算用量仅看 exclude_from_budget,与 exclude_from_stats 独立。
+            # 标记排除预算的交易不计入用量(total + category 共用此 base_q)。
+            ReadTxProjection.exclude_from_budget == sa_false(),
         )
         if (b.budget_type or "total") == "category" and b.category_sync_id:
             # parent + 所有 parent_sync_id 指向它的子分类

--- a/src/routers/read/ledgers.py
+++ b/src/routers/read/ledgers.py
@@ -327,6 +327,8 @@ def list_transactions(
                 tags_list=_tags_list(row.tags_csv),
                 tag_ids=tag_ids,
                 attachments=attachments,
+                exclude_from_stats=bool(row.exclude_from_stats),
+                exclude_from_budget=bool(row.exclude_from_budget),
                 last_change_id=source_change_id,
                 ledger_id=ledger.external_id,
                 ledger_name=ledger_name,

--- a/src/routers/read/workspace.py
+++ b/src/routers/read/workspace.py
@@ -204,6 +204,8 @@ def list_workspace_transactions(
                 tags_list=_tags_list(row.tags_csv),
                 tag_ids=tag_ids,
                 attachments=attachments,
+                exclude_from_stats=bool(row.exclude_from_stats),
+                exclude_from_budget=bool(row.exclude_from_budget),
                 last_change_id=change_id,
                 ledger_id=led_ext_id,
                 ledger_name=led_name,

--- a/src/routers/read/workspace.py
+++ b/src/routers/read/workspace.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import statistics as _stats
 
 from pydantic import BaseModel
+from sqlalchemy import false as sa_false
 
 from ._shared import *  # noqa: F401,F403 — imports + helpers + router
 from ...models import ExchangeRateCache, UserExchangeRateProjection
@@ -992,7 +993,14 @@ def workspace_analytics(
             ReadTxProjection.amount,
             ReadTxProjection.happened_at,
             ReadTxProjection.category_name,
-        ).where(ReadTxProjection.ledger_id.in_(ledger_internal_ids))
+        ).where(
+            ReadTxProjection.ledger_id.in_(ledger_internal_ids),
+            # exclude_from_stats=True 的交易不计入收支统计(D1);该端点所有
+            # 数字(income/expense 汇总、series、分类排行、anomaly)都源自这一
+            # 查询,故在此一处过滤即覆盖全部收支口径。余额/净值口径在
+            # workspace_net_worth_history 端点,不受此过滤影响。
+            ReadTxProjection.exclude_from_stats == sa_false(),
+        )
         if start_at is not None:
             tx_query = tx_query.where(ReadTxProjection.happened_at >= start_at)
         if end_at is not None:

--- a/src/routers/write/_shared.py
+++ b/src/routers/write/_shared.py
@@ -888,6 +888,10 @@ def _projection_row_to_tx_dict(row: ReadTxProjection) -> dict[str, Any]:
         item["txIndex"] = row.tx_index
     if row.created_by_user_id:
         item["createdByUserId"] = row.created_by_user_id
+    # 账单标记(.docs/transaction-flags):带上当前值,update merge 不传该字段时
+    # 保留原值,且新 SyncChange payload 用 camelCase 携带它们。
+    item["excludeFromStats"] = bool(row.exclude_from_stats)
+    item["excludeFromBudget"] = bool(row.exclude_from_budget)
     return item
 
 

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -517,6 +517,10 @@ class ReadTransactionOut(BaseModel):
     tags_list: list[str] = Field(default_factory=list)
     tag_ids: list[str] = Field(default_factory=list)
     attachments: list[dict[str, Any]] | None
+    # 账单标记(.docs/transaction-flags)。exclude_from_stats=不计入收支统计;
+    # exclude_from_budget=不计入预算用量。两者独立,旧数据 default False。
+    exclude_from_stats: bool = False
+    exclude_from_budget: bool = False
     last_change_id: int
     ledger_id: str | None = None
     ledger_name: str | None = None
@@ -795,6 +799,9 @@ class WriteTransactionCreateRequest(WriteBaseRequest):
     tags: str | list[str] | None = None
     tag_ids: list[str] | None = None
     attachments: list[dict[str, Any]] | None = None
+    # 账单标记(.docs/transaction-flags)。新建默认 False。
+    exclude_from_stats: bool = False
+    exclude_from_budget: bool = False
 
 
 class WriteTransactionUpdateRequest(WriteBaseRequest):
@@ -814,6 +821,9 @@ class WriteTransactionUpdateRequest(WriteBaseRequest):
     tags: str | list[str] | None = None
     tag_ids: list[str] | None = None
     attachments: list[dict[str, Any]] | None = None
+    # 账单标记(.docs/transaction-flags)。None = 不变(沿用 update 其它字段语义)。
+    exclude_from_stats: bool | None = None
+    exclude_from_budget: bool | None = None
 
 
 class WriteEntityDeleteRequest(WriteBaseRequest):

--- a/src/snapshot_mutator.py
+++ b/src/snapshot_mutator.py
@@ -317,6 +317,10 @@ def create_transaction(snapshot: dict, payload: dict) -> tuple[dict, str]:
     attachments = payload.get("attachments")
     if isinstance(attachments, list):
         item["attachments"] = attachments
+    # 账单标记(.docs/transaction-flags):snapshot 用 camelCase,跟 mobile
+    # serializer + projection.upsert_tx(读 excludeFromStats)对齐。create 默认 False。
+    item["excludeFromStats"] = bool(payload.get("exclude_from_stats"))
+    item["excludeFromBudget"] = bool(payload.get("exclude_from_budget"))
     _mark_entity_actor(item, payload, create=True)
 
     _ensure_list(target, "items").append(item)
@@ -393,6 +397,15 @@ def update_transaction(snapshot: dict, tx_id: str, payload: dict) -> dict:
             item["attachments"] = attachments
         elif attachments is None:
             item.pop("attachments", None)
+    # 账单标记(.docs/transaction-flags):web update 请求里 None = 不变(由
+    # exclude_unset 的 payload 控制:不传该 key 就不进 payload)。带显式布尔
+    # 才写。snapshot 用 camelCase。
+    for req_key, snapshot_key in (
+        ("exclude_from_stats", "excludeFromStats"),
+        ("exclude_from_budget", "excludeFromBudget"),
+    ):
+        if req_key in payload and payload.get(req_key) is not None:
+            item[snapshot_key] = bool(payload.get(req_key))
     _mark_entity_actor(item, payload, create=False)
 
     # 方案 B 后 snapshot 不写回 DB,items 排序只对 mutator 内部无意义 → 跳过(原 30ms/5k)。

--- a/src/sync_applier.py
+++ b/src/sync_applier.py
@@ -193,6 +193,10 @@ _LEDGER_MERGE_SPECS: dict[str, _MergeSpec] = {
         # 共享账本 Phase 1:updatedByUserId 也回写到 projection,作为
         # last_edited_by。snapshot_mutator._mark_entity_actor 写入。
         ("updatedByUserId", "last_edited_by_user_id"),
+        # 账单标记(.docs/transaction-flags)。merge 时缺键保留既有行值,
+        # 布尔强转在 projection.upsert_tx(default=False)做。
+        ("excludeFromStats", "exclude_from_stats"),
+        ("excludeFromBudget", "exclude_from_budget"),
     ]),
 }
 

--- a/tests/test_analytics_exclude_flags.py
+++ b/tests/test_analytics_exclude_flags.py
@@ -1,0 +1,150 @@
+"""收支分析端点 /read/workspace/analytics 按 exclude_from_stats 过滤(D1):
+
+- exclude_from_stats=True 的交易不计入 income/expense 汇总(summary + series + 分类排行)
+- 该标记只改"统计算不算它",不改"钱的位置";余额/净值口径在另一个端点
+  (net-worth-history),本测试只锁收支汇总。
+
+push 用 app token(SCOPE_APP_WRITE),读用 web token(SCOPE_WEB_READ),
+与 test_net_worth_history.py 同套 fixture。
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.database import Base, get_db
+from src.main import app
+
+
+def _make_client():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TS = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    def override():
+        db = TS()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override
+    return TestClient(app), TS
+
+
+def _iso(dt=None):
+    return (dt or datetime.now(timezone.utc)).isoformat()
+
+
+def _register_and_token(
+    client: TestClient, email: str, *, device_id: str, client_type: str
+) -> str:
+    client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "password": "Pa$$word1!",
+            "device_id": device_id,
+            "client_type": client_type,
+            "device_name": f"pytest-{client_type}",
+            "platform": "test",
+        },
+    )
+    r = client.post(
+        "/api/v1/auth/login",
+        json={
+            "email": email,
+            "password": "Pa$$word1!",
+            "device_id": device_id,
+            "client_type": client_type,
+            "device_name": f"pytest-{client_type}",
+            "platform": "test",
+        },
+    )
+    return r.json()["access_token"]
+
+
+def _two_tokens(client, email):
+    app_token = _register_and_token(client, email, device_id="d-app", client_type="app")
+    web_token = _register_and_token(client, email, device_id="d-web", client_type="web")
+    return app_token, web_token
+
+
+def _push(client, hdr, ledger_id, entity_type, sync_id, payload, *, action="upsert"):
+    body = {
+        "ledger_id": ledger_id,
+        "entity_type": entity_type,
+        "entity_sync_id": sync_id,
+        "action": action,
+        "updated_at": _iso(),
+        "payload": payload,
+    }
+    r = client.post(
+        "/api/v1/sync/push",
+        headers=hdr,
+        json={"device_id": "d-app", "changes": [body]},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_analytics_excludes_exclude_from_stats_transactions():
+    """同账本两笔同周期支出:普通 100、exclude_from_stats=True 的 500;
+    再加一笔 exclude_from_stats=True 的收入 300。
+    expense_total 应只反映 100(非 600),income_total 应为 0。"""
+    client, _ = _make_client()
+    try:
+        app_token, web_token = _two_tokens(client, "excl-an@t.com")
+        hdr_app = {"Authorization": f"Bearer {app_token}"}
+        hdr_web = {"Authorization": f"Bearer {web_token}"}
+
+        _push(client, hdr_app, "lg1", "ledger", "lg1",
+              {"syncId": "lg1", "ledgerName": "个人账本", "currency": "CNY"})
+
+        # 普通支出 100 —— 应计入
+        _push(client, hdr_app, "lg1", "transaction", "tx-normal",
+              {"syncId": "tx-normal", "type": "expense", "amount": 100,
+               "categoryName": "餐饮",
+               "happenedAt": "2026-06-15T00:00:00+00:00"})
+        # exclude_from_stats 支出 500 —— 不应计入
+        _push(client, hdr_app, "lg1", "transaction", "tx-excluded",
+              {"syncId": "tx-excluded", "type": "expense", "amount": 500,
+               "categoryName": "餐饮",
+               "excludeFromStats": True,
+               "happenedAt": "2026-06-16T00:00:00+00:00"})
+        # exclude_from_stats 收入 300 —— 不应计入
+        _push(client, hdr_app, "lg1", "transaction", "tx-inc-excluded",
+              {"syncId": "tx-inc-excluded", "type": "income", "amount": 300,
+               "categoryName": "工资",
+               "excludeFromStats": True,
+               "happenedAt": "2026-06-17T00:00:00+00:00"})
+
+        r = client.get(
+            "/api/v1/read/workspace/analytics",
+            headers=hdr_web,
+            params={"scope": "all", "metric": "expense"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        summary = body["summary"]
+
+        # 支出只算普通的 100,不含被标记的 500
+        assert summary["expense_total"] == 100.0
+        # 收入被标记笔排除,应为 0
+        assert summary["income_total"] == 0.0
+        # balance = income - expense = -100
+        assert summary["balance"] == -100.0
+
+        # 分类排行同样只反映普通支出
+        ranks = {row["category_name"]: row["total"] for row in body["category_ranks"]}
+        assert ranks.get("餐饮") == 100.0
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_budget_usage_exclude_flags.py
+++ b/tests/test_budget_usage_exclude_flags.py
@@ -1,0 +1,211 @@
+"""服务端预算用量按 exclude_from_budget 过滤(设计 D2):
+
+预算 used 只看 exclude_from_budget,不看 exclude_from_stats —— 两标记独立。
+- exclude_from_budget=True 的交易 → 不计入预算用量
+- exclude_from_stats=True 但 exclude_from_budget=False 的交易 → 仍计入预算用量
+
+交易标记只能通过 /sync/push 的 camelCase payload 设置(写端点不收该字段),
+预算通过 web write 端点创建。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.database import Base, get_db
+from src.main import app
+
+
+def _make_client() -> TestClient:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TS = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    def override():
+        db = TS()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override
+    return TestClient(app)
+
+
+def _register(client: TestClient, email: str) -> dict:
+    res = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "password": "123456",
+            "client_type": "app",
+            "device_name": "pytest-app",
+            "platform": "app",
+        },
+    )
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _login_web(client: TestClient, email: str) -> dict:
+    res = client.post(
+        "/api/v1/auth/login",
+        json={
+            "email": email,
+            "password": "123456",
+            "client_type": "web",
+            "device_name": "pytest-web",
+            "platform": "web",
+        },
+    )
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _seed_ledger(client: TestClient, token: str, device_id: str, ledger_id: str) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    content = (
+        f'{{"ledgerName":"{ledger_id}","currency":"CNY","count":0,'
+        '"items":[],"accounts":[],"categories":[],"tags":[]}'
+    )
+    res = client.post(
+        "/api/v1/sync/push",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "device_id": device_id,
+            "changes": [
+                {
+                    "ledger_id": ledger_id,
+                    "entity_type": "ledger_snapshot",
+                    "entity_sync_id": ledger_id,
+                    "action": "upsert",
+                    "payload": {"content": content},
+                    "updated_at": now,
+                }
+            ],
+        },
+    )
+    assert res.status_code == 200, res.text
+
+
+def _latest_change_id(client: TestClient, token: str, ledger_id: str) -> int:
+    res = client.get(
+        f"/api/v1/read/ledgers/{ledger_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200, res.text
+    return int(res.json()["source_change_id"])
+
+
+def _push_tx(
+    client: TestClient, token: str, device_id: str, ledger_id: str, payload: dict
+) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    res = client.post(
+        "/api/v1/sync/push",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "device_id": device_id,
+            "changes": [
+                {
+                    "ledger_id": ledger_id,
+                    "entity_type": "transaction",
+                    "entity_sync_id": payload["syncId"],
+                    "action": "upsert",
+                    "payload": payload,
+                    "updated_at": now,
+                }
+            ],
+        },
+    )
+    assert res.status_code == 200, res.text
+
+
+def test_total_budget_usage_excludes_exclude_from_budget_only() -> None:
+    client = _make_client()
+    try:
+        owner = _register(client, "bef@example.com")
+        app_token, device = owner["access_token"], owner["device_id"]
+        ledger_id = "L_BUDGET_EXCL"
+        _seed_ledger(client, app_token, device, ledger_id)
+
+        # 当前周期内的 happened_at(start_day 默认 1 → 本月 1 日到下月 1 日)
+        happened = (
+            datetime.now(timezone.utc)
+            .replace(hour=12, minute=0, second=0, microsecond=0)
+            .isoformat()
+        )
+
+        # (a) 普通支出 100 —— 计入
+        _push_tx(
+            client, app_token, device, ledger_id,
+            {
+                "syncId": "tx-normal",
+                "type": "expense",
+                "amount": 100.0,
+                "happenedAt": happened,
+            },
+        )
+        # (b) exclude_from_budget=True 支出 500 —— 不计入
+        _push_tx(
+            client, app_token, device, ledger_id,
+            {
+                "syncId": "tx-excl-budget",
+                "type": "expense",
+                "amount": 500.0,
+                "happenedAt": happened,
+                "excludeFromBudget": True,
+            },
+        )
+        # (c) exclude_from_stats=True 但 exclude_from_budget=False 支出 30 —— 仍计入
+        _push_tx(
+            client, app_token, device, ledger_id,
+            {
+                "syncId": "tx-excl-stats",
+                "type": "expense",
+                "amount": 30.0,
+                "happenedAt": happened,
+                "excludeFromStats": True,
+                "excludeFromBudget": False,
+            },
+        )
+
+        # 用 web token 创建总预算(写端点要求 web scope)
+        web = _login_web(client, "bef@example.com")
+        token = web["access_token"]
+        base = _latest_change_id(client, token, ledger_id)
+        res = client.post(
+            f"/api/v1/write/ledgers/{ledger_id}/budgets",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "base_change_id": base,
+                "type": "total",
+                "amount": 5000,
+                "start_day": 1,
+            },
+        )
+        assert res.status_code == 200, res.text
+
+        res = client.get(
+            f"/api/v1/read/ledgers/{ledger_id}/budgets/usage",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert res.status_code == 200, res.text
+        items = res.json()["items"]
+        assert len(items) == 1
+        # D2: (b) 被排除,(c) 仍计入 → 100 + 30 = 130
+        assert items[0]["used"] == 130.0, (
+            f"expected 130.0 (100+30, exclude_from_budget excluded, "
+            f"exclude_from_stats still counted), got {items[0]['used']}"
+        )
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_sync_exclude_flags.py
+++ b/tests/test_sync_exclude_flags.py
@@ -1,0 +1,183 @@
+"""交易标记(exclude_from_stats / exclude_from_budget)同步契约 — push 侧:
+
+- mobile push 的 transaction upsert payload 带 camelCase
+  `excludeFromStats` / `excludeFromBudget` → 落 read_tx_projection 两列
+- partial-update(后续 push 不带该 key)时保持原值(merge 契约,D6 核心),
+  不得被抹成 False
+
+read 端过滤(收支分析 / 预算用量)与 schema/写端契约由后续任务追加。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.database import Base, get_db
+from src.main import app
+from src.models import Ledger, ReadTxProjection
+
+
+def _make_client():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TS = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    def override():
+        db = TS()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override
+    return TestClient(app), TS
+
+
+def _register(client: TestClient, email: str) -> dict:
+    res = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "password": "123456",
+            "client_type": "app",
+            "device_name": "pytest-app",
+            "platform": "app",
+        },
+    )
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _seed_ledger(client: TestClient, token: str, device_id: str, ledger_id: str) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    content = (
+        f'{{"ledgerName":"{ledger_id}","currency":"CNY","count":0,'
+        '"items":[],"accounts":[],"categories":[],"tags":[]}'
+    )
+    res = client.post(
+        "/api/v1/sync/push",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "device_id": device_id,
+            "changes": [
+                {
+                    "ledger_id": ledger_id,
+                    "entity_type": "ledger_snapshot",
+                    "entity_sync_id": ledger_id,
+                    "action": "upsert",
+                    "payload": {"content": content},
+                    "updated_at": now,
+                }
+            ],
+        },
+    )
+    assert res.status_code == 200, res.text
+
+
+def _push_tx(
+    client: TestClient, token: str, device_id: str, ledger_id: str, payload: dict
+) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    res = client.post(
+        "/api/v1/sync/push",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "device_id": device_id,
+            "changes": [
+                {
+                    "ledger_id": ledger_id,
+                    "entity_type": "transaction",
+                    "entity_sync_id": payload["syncId"],
+                    "action": "upsert",
+                    "payload": payload,
+                    "updated_at": now,
+                }
+            ],
+        },
+    )
+    assert res.status_code == 200, res.text
+
+
+def _tx_row(TS, external_ledger_id: str, sync_id: str) -> ReadTxProjection:
+    with TS() as db:
+        internal_id = db.scalar(
+            select(Ledger.id).where(Ledger.external_id == external_ledger_id)
+        )
+        assert internal_id is not None
+        row = db.scalar(
+            select(ReadTxProjection).where(
+                ReadTxProjection.ledger_id == internal_id,
+                ReadTxProjection.sync_id == sync_id,
+            )
+        )
+        assert row is not None
+        db.expunge(row)
+        return row
+
+
+def test_push_transaction_persists_exclude_flags() -> None:
+    client, TS = _make_client()
+    try:
+        owner = _register(client, "excl1@example.com")
+        token, device = owner["access_token"], owner["device_id"]
+        _seed_ledger(client, token, device, "L_EXCL1")
+        _push_tx(
+            client, token, device, "L_EXCL1",
+            {
+                "syncId": "tx-flag-1",
+                "type": "expense",
+                "amount": 500.0,
+                "happenedAt": datetime.now(timezone.utc).isoformat(),
+                "excludeFromStats": True,
+                "excludeFromBudget": True,
+            },
+        )
+        row = _tx_row(TS, "L_EXCL1", "tx-flag-1")
+        assert row.exclude_from_stats is True
+        assert row.exclude_from_budget is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_partial_update_preserves_exclude_flags() -> None:
+    client, TS = _make_client()
+    try:
+        owner = _register(client, "excl2@example.com")
+        token, device = owner["access_token"], owner["device_id"]
+        _seed_ledger(client, token, device, "L_EXCL2")
+        # 先推一条带 excludeFromStats 的交易
+        _push_tx(
+            client, token, device, "L_EXCL2",
+            {
+                "syncId": "tx-flag-2",
+                "type": "expense",
+                "amount": 500.0,
+                "happenedAt": datetime.now(timezone.utc).isoformat(),
+                "excludeFromStats": True,
+            },
+        )
+        # 再推一条只改金额、不带 excludeFromStats 键的 partial update
+        _push_tx(
+            client, token, device, "L_EXCL2",
+            {
+                "syncId": "tx-flag-2",
+                "type": "expense",
+                "amount": 600.0,
+                "happenedAt": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+        row = _tx_row(TS, "L_EXCL2", "tx-flag-2")
+        assert row.amount == 600.0
+        # 标记必须保留,不被抹成 False(D6 核心)
+        assert row.exclude_from_stats is True
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_write_tx_exclude_flags.py
+++ b/tests/test_write_tx_exclude_flags.py
@@ -1,0 +1,256 @@
+"""Task 5: 交易读/写 schema + Web 写端点支持 exclude 标记。
+
+覆盖:
+  - web POST /write/ledgers/{id}/transactions 接收 exclude_from_stats /
+    exclude_from_budget,RESPONSE(经 read 端点)能读回这两个布尔。
+  - 发出的 SyncChange payload 用 camelCase excludeFromStats / excludeFromBudget
+    (跟 mobile serializer + Task 2 _LEDGER_MERGE_SPECS 对齐)。
+  - projection 行落库 exclude_from_stats / exclude_from_budget。
+  - web PATCH 切换某个 flag,另一个不传时保持不变。
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.database import Base, get_db
+from src.main import app
+from src.models import Ledger, ReadTxProjection, SyncChange
+
+
+def _make_client():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TS = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    def override():
+        db = TS()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override
+    return TestClient(app), TS
+
+
+def _iso(dt=None):
+    return (dt or datetime.now(timezone.utc)).isoformat()
+
+
+def _register(client: TestClient, email: str) -> dict:
+    res = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "password": "123456",
+            "client_type": "app",
+            "device_name": "pytest-app",
+            "platform": "app",
+        },
+    )
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _login_web(client: TestClient, email: str) -> dict:
+    res = client.post(
+        "/api/v1/auth/login",
+        json={
+            "email": email,
+            "password": "123456",
+            "client_type": "web",
+            "device_name": "pytest-web",
+            "platform": "web",
+        },
+    )
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _seed_ledger(client: TestClient, token: str, device_id: str, ledger_id: str) -> None:
+    now = _iso()
+    content = (
+        f'{{"ledgerName":"{ledger_id}","currency":"CNY","count":0,'
+        '"items":[],"accounts":[],"categories":[],"tags":[]}'
+    )
+    res = client.post(
+        "/api/v1/sync/push",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "device_id": device_id,
+            "changes": [
+                {
+                    "ledger_id": ledger_id,
+                    "entity_type": "ledger_snapshot",
+                    "entity_sync_id": ledger_id,
+                    "action": "upsert",
+                    "payload": {"content": content},
+                    "updated_at": now,
+                }
+            ],
+        },
+    )
+    assert res.status_code == 200, res.text
+
+
+def _ledger_internal_id(TS, external_id: str) -> str:
+    with TS() as db:
+        return db.scalar(select(Ledger.id).where(Ledger.external_id == external_id))
+
+
+def _base_change_id(client: TestClient, web_token: str, ledger_id: str) -> int:
+    res = client.get(
+        f"/api/v1/read/ledgers/{ledger_id}",
+        headers={"Authorization": f"Bearer {web_token}"},
+    )
+    assert res.status_code == 200, res.text
+    return int(res.json()["source_change_id"])
+
+
+def _latest_tx_change_payload(TS, ledger_internal_id: str, tx_id: str) -> dict:
+    with TS() as db:
+        row = db.scalar(
+            select(SyncChange)
+            .where(
+                SyncChange.ledger_id == ledger_internal_id,
+                SyncChange.entity_type == "transaction",
+                SyncChange.entity_sync_id == tx_id,
+            )
+            .order_by(SyncChange.change_id.desc())
+        )
+        assert row is not None, "no SyncChange for tx"
+        return row.payload_json
+
+
+# --------------------------------------------------------------------------- #
+# Test 1: web create with flags → response + SyncChange + projection           #
+# --------------------------------------------------------------------------- #
+
+def test_web_create_tx_with_exclude_flags() -> None:
+    client, TS = _make_client()
+    try:
+        owner = _register(client, "exflag_c1@example.com")
+        token, device = owner["access_token"], owner["device_id"]
+        _seed_ledger(client, token, device, "EX_C1")
+
+        web_token = _login_web(client, "exflag_c1@example.com")["access_token"]
+        web_hdr = {"Authorization": f"Bearer {web_token}", "X-Device-ID": "pytest-web"}
+        base = _base_change_id(client, web_token, "EX_C1")
+
+        create_res = client.post(
+            "/api/v1/write/ledgers/EX_C1/transactions",
+            headers=web_hdr,
+            json={
+                "base_change_id": base,
+                "tx_type": "expense",
+                "amount": 42.0,
+                "happened_at": _iso(),
+                "exclude_from_stats": True,
+                "exclude_from_budget": False,
+            },
+        )
+        assert create_res.status_code == 200, create_res.text
+        tx_id = create_res.json()["entity_id"]
+
+        # read 端点能读回这两个布尔
+        list_res = client.get(
+            "/api/v1/read/ledgers/EX_C1/transactions",
+            headers={"Authorization": f"Bearer {web_token}"},
+        )
+        assert list_res.status_code == 200, list_res.text
+        items = [it for it in list_res.json() if it["id"] == tx_id]
+        assert len(items) == 1, f"tx {tx_id} not in read list"
+        item = items[0]
+        assert item["exclude_from_stats"] is True
+        assert item["exclude_from_budget"] is False
+
+        # SyncChange payload 用 camelCase
+        lid = _ledger_internal_id(TS, "EX_C1")
+        payload = _latest_tx_change_payload(TS, lid, tx_id)
+        assert payload.get("excludeFromStats") is True, payload
+        assert payload.get("excludeFromBudget") is False, payload
+
+        # projection 落库
+        with TS() as db:
+            row = db.scalar(
+                select(ReadTxProjection).where(
+                    ReadTxProjection.ledger_id == lid,
+                    ReadTxProjection.sync_id == tx_id,
+                )
+            )
+            assert row is not None
+            assert row.exclude_from_stats is True
+            assert row.exclude_from_budget is False
+    finally:
+        app.dependency_overrides.clear()
+
+
+# --------------------------------------------------------------------------- #
+# Test 2: web update toggles one flag, other unchanged                          #
+# --------------------------------------------------------------------------- #
+
+def test_web_update_tx_toggle_flag() -> None:
+    client, TS = _make_client()
+    try:
+        owner = _register(client, "exflag_u1@example.com")
+        token, device = owner["access_token"], owner["device_id"]
+        _seed_ledger(client, token, device, "EX_U1")
+
+        web_token = _login_web(client, "exflag_u1@example.com")["access_token"]
+        web_hdr = {"Authorization": f"Bearer {web_token}", "X-Device-ID": "pytest-web"}
+        base = _base_change_id(client, web_token, "EX_U1")
+
+        # create with both False
+        create_res = client.post(
+            "/api/v1/write/ledgers/EX_U1/transactions",
+            headers=web_hdr,
+            json={
+                "base_change_id": base,
+                "tx_type": "expense",
+                "amount": 10.0,
+                "happened_at": _iso(),
+                "exclude_from_stats": False,
+                "exclude_from_budget": True,
+            },
+        )
+        assert create_res.status_code == 200, create_res.text
+        tx_id = create_res.json()["entity_id"]
+        new_base = int(create_res.json()["new_change_id"])
+
+        # update: flip exclude_from_stats only, omit exclude_from_budget
+        upd_res = client.patch(
+            f"/api/v1/write/ledgers/EX_U1/transactions/{tx_id}",
+            headers=web_hdr,
+            json={
+                "base_change_id": new_base,
+                "exclude_from_stats": True,
+            },
+        )
+        assert upd_res.status_code == 200, upd_res.text
+
+        lid = _ledger_internal_id(TS, "EX_U1")
+        with TS() as db:
+            row = db.scalar(
+                select(ReadTxProjection).where(
+                    ReadTxProjection.ledger_id == lid,
+                    ReadTxProjection.sync_id == tx_id,
+                )
+            )
+            assert row is not None
+            assert row.exclude_from_stats is True, "stats flag should be toggled on"
+            assert row.exclude_from_budget is True, "budget flag must remain unchanged"
+
+        payload = _latest_tx_change_payload(TS, lid, tx_id)
+        assert payload.get("excludeFromStats") is True, payload
+        assert payload.get("excludeFromBudget") is True, payload
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
对应 App issue [#340](https://github.com/TNT-Likely/BeeCount/issues/340)「账单标记」的**云端先行**部分(设计见 App 仓 `.docs/transaction-flags/`,Cloud 技术设计 03 文档)。

## 做了什么

给交易加两个**互相独立**的布尔标记:
- `exclude_from_stats`(不计入收支)— 仅从收支统计/分析剔除,**不影响余额/净资产**(D1/D5);
- `exclude_from_budget`(不计入预算)— 仅从预算用量剔除(D2,与上者独立)。

## 改动(6 提交,TDD)

1. **migration 0017 + 模型**:`read_tx_projection` 加两列(Boolean NOT NULL default false,chain 自 0016)。
2. **同步**:`_LEDGER_MERGE_SPECS["transaction"]` + `upsert_tx` 接两字段;partial-update 缺键**保留**既有值不抹掉(D6)。
3. **收支分析**:`workspace_analytics` 的 `tx_query` 过滤 `exclude_from_stats`;余额/净值查询不动。
4. **预算用量**:`list_budgets_usage` 的 `base_q` 过滤 `exclude_from_budget`(总预算 + 分类预算共用)。
5. **schema + Web 写端点**:读响应返回两字段;create/update 接受;经 snapshot mutator 写入并发射 camelCase `excludeFromStats`/`excludeFromBudget` 的 SyncChange。
6. **Web 前端**:列表第二排小灰字标签「不计收支」/「不计预算」;编辑开关按类型条件显示(收支=收/支,预算=仅支出);三语 i18n。

## 验证

- 后端全量 `pytest tests/ -q` → **373 passed**;4 个新测试文件覆盖 D1/D2/D6 + 写端点往返。
- 前端 `tsc -b` + `vite build` 均通过。
- 独立 code review:6 项不变量全部确认,无 Critical/Important。

## 字段契约(给 App PR 注意)

同步 payload 键 = camelCase `excludeFromStats`/`excludeFromBudget`;DB/读响应/HTTP body = snake_case。App 端 `EntitySerializer` 落地时必须用这两个 camelCase 键,否则跨端静默丢标记。

## 兼容/发布

- `server_default=false` → 既有行升级后过滤≈不过滤,旧 App 无感。
- `/sync/pull` 回放 payload 原文,故新标记在增量同步下旧服务器也跨端存活;`/sync/full` 从 projection 重建,旧服务器全量同步会丢标记 —— **Cloud 先发**即解。
- 发布顺序:本 PR 先合并部署,App 端随后。