### PR TITLE
feat: 货币列表扩充至全量 ISO 4217(151 种)

### DIFF
--- a/frontend/apps/web/src/currencies.test.ts
+++ b/frontend/apps/web/src/currencies.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { CURRENCY_CODES, currencyDisplayName } from '@beecount/web-features'
+
+describe('currencies', () => {
+  it('CURRENCY_CODES 覆盖全部 + 含 issue#273 请求的 KES/XAF/XOF', () => {
+    expect(CURRENCY_CODES.length).toBe(151)
+    expect(CURRENCY_CODES).toEqual(
+      expect.arrayContaining(['KES', 'XAF', 'XOF', 'CNY', 'USD', 'EUR', 'JPY']),
+    )
+  })
+
+  it('code 无重复', () => {
+    expect(new Set(CURRENCY_CODES).size).toBe(CURRENCY_CODES.length)
+  })
+
+  it('currencyDisplayName 用 Intl 本地化,大小写不敏感,未知 code 回退自身', () => {
+    expect(currencyDisplayName('USD', 'en')).toBe('US Dollar')
+    expect(currencyDisplayName('KES', 'en')).toBe('Kenyan Shilling')
+    expect(currencyDisplayName('usd', 'en')).toBe('US Dollar')
+    expect(currencyDisplayName('ZZZ', 'en')).toBe('ZZZ')
+  })
+
+  it('中文 locale 返回本地化名', () => {
+    expect(currencyDisplayName('USD', 'zh-CN')).toBe('美元')
+  })
+})

--- a/frontend/apps/web/src/i18n/en.ts
+++ b/frontend/apps/web/src/i18n/en.ts
@@ -1185,6 +1185,7 @@ const en = {
   'currency.region.middleEast': 'Middle East',
   'currency.region.europe': 'Europe',
   'currency.region.northAmerica': 'North America',
+  'currency.region.centralAmericaCaribbean': 'Central America & Caribbean',
   'currency.region.southAmerica': 'South America',
   'currency.region.oceania': 'Oceania',
   'currency.region.africa': 'Africa',

--- a/frontend/apps/web/src/i18n/zh-CN.ts
+++ b/frontend/apps/web/src/i18n/zh-CN.ts
@@ -1227,6 +1227,7 @@ const zhCN = {
   'currency.region.middleEast': '西亚 / 中东',
   'currency.region.europe': '欧洲',
   'currency.region.northAmerica': '北美',
+  'currency.region.centralAmericaCaribbean': '中美洲及加勒比',
   'currency.region.southAmerica': '南美',
   'currency.region.oceania': '大洋洲',
   'currency.region.africa': '非洲',

--- a/frontend/apps/web/src/i18n/zh-TW.ts
+++ b/frontend/apps/web/src/i18n/zh-TW.ts
@@ -1186,6 +1186,7 @@ const zhTW = {
   'currency.region.middleEast': '西亞 / 中東',
   'currency.region.europe': '歐洲',
   'currency.region.northAmerica': '北美',
+  'currency.region.centralAmericaCaribbean': '中美洲及加勒比',
   'currency.region.southAmerica': '南美',
   'currency.region.oceania': '大洋洲',
   'currency.region.africa': '非洲',

--- a/frontend/packages/web-features/src/components/CurrencySelector.tsx
+++ b/frontend/packages/web-features/src/components/CurrencySelector.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import {
   Button,
@@ -8,10 +8,11 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
+  useLocale,
   useT,
 } from '@beecount/ui'
 
-import { CURRENCY_REGION_GROUPS } from '../lib/currencies'
+import { CURRENCY_REGION_GROUPS, currencyDisplayName } from '../lib/currencies'
 
 type CurrencySelectorProps = {
   open: boolean
@@ -47,9 +48,21 @@ export function CurrencySelector({
   readOnlyHint,
 }: CurrencySelectorProps) {
   const t = useT()
+  const { locale } = useLocale()
   const [query, setQuery] = useState('')
 
   const normalizedValue = (value || '').trim().toUpperCase()
+
+  // 币种显示名:优先用 i18n key(主流币种人工译名)覆盖,否则用 Intl.DisplayNames
+  // 按当前语言本地化(长尾币种也能出名字)。
+  const resolveName = useCallback(
+    (code: string): string => {
+      const i18nKey = `currency.${code}`
+      const i18n = t(i18nKey)
+      return i18n === i18nKey ? currencyDisplayName(code, locale) : i18n
+    },
+    [t, locale],
+  )
 
   // 把分组结构按搜索词过滤一遍,空 region 不渲染。
   const filteredGroups = useMemo(() => {
@@ -57,14 +70,12 @@ export function CurrencySelector({
     return CURRENCY_REGION_GROUPS.map((group) => {
       const codes = group.codes.filter((code) => {
         if (!q) return true
-        const i18nKey = `currency.${code}`
-        const name = t(i18nKey)
-        const localized = name === i18nKey ? '' : name.toLowerCase()
-        return code.toLowerCase().includes(q) || localized.includes(q)
+        const name = resolveName(code).toLowerCase()
+        return code.toLowerCase().includes(q) || name.includes(q)
       })
       return { ...group, codes }
     }).filter((group) => group.codes.length > 0)
-  }, [query, t])
+  }, [query, resolveName])
 
   return (
     <Dialog
@@ -107,9 +118,8 @@ export function CurrencySelector({
                   </div>
                   <div className="grid grid-cols-1 gap-1 sm:grid-cols-2">
                     {group.codes.map((code) => {
-                      const i18nKey = `currency.${code}`
-                      const name = t(i18nKey)
-                      const display = name === i18nKey ? code : `${name} (${code})`
+                      const name = resolveName(code)
+                      const display = name && name !== code ? `${name} (${code})` : code
                       const selected = normalizedValue === code
                       return (
                         <button

--- a/frontend/packages/web-features/src/lib/currencies.ts
+++ b/frontend/packages/web-features/src/lib/currencies.ts
@@ -1,26 +1,44 @@
 /**
- * 跟 mobile `lib/utils/currencies.dart` 保持同一份货币 code 列表(~40 个)。
- * 新增货币只需在此追加,前端两端都得同步更新。
+ * 跟 mobile `lib/utils/currencies.dart` 保持同一份货币 code 列表(151 个,
+ * 覆盖通行 ISO 4217;全部在汇率源 fawaz currency-api 有报价)。新增货币只需在
+ * 此追加,前端两端都得同步更新。
  *
- * 不再单独维护 symbol 表 —— web 上目前没有展示 symbol 的地方,需要时
- * 可以从 [Intl.NumberFormat] 派生(`new Intl.NumberFormat('zh-CN',
- * { style: 'currency', currency: code }).formatToParts(0).find(p => p.type === 'currency')?.value`),
- * 不必在这里再硬编码一份。
+ * 不单独维护 symbol 表 —— web 上目前没有展示 symbol 的地方,需要时可从
+ * [Intl.NumberFormat] 派生。币种名称同理走 [Intl.DisplayNames](见
+ * [currencyDisplayName]),主流币种由 i18n key `currency.<CODE>` 覆盖。
  */
 
 const CURRENCY_GROUPS: Array<{ region: string; codes: string[] }> = [
-  { region: 'eastAsia', codes: ['CNY', 'JPY', 'KRW', 'HKD', 'TWD'] },
-  { region: 'southeastAsia', codes: ['SGD', 'MYR', 'THB', 'IDR', 'PHP', 'VND', 'MMK'] },
-  { region: 'southAsia', codes: ['INR', 'PKR', 'BDT', 'LKR'] },
-  { region: 'centralAsia', codes: ['KZT'] },
-  { region: 'middleEast', codes: ['AED', 'SAR', 'ILS', 'TRY'] },
-  { region: 'europe', codes: ['EUR', 'GBP', 'CHF', 'SEK', 'NOK', 'DKK', 'PLN', 'CZK', 'HUF', 'RUB', 'BYN', 'UAH'] },
+  { region: 'eastAsia', codes: ['CNY', 'JPY', 'KRW', 'HKD', 'TWD', 'MOP', 'MNT', 'KPW'] },
+  { region: 'southeastAsia', codes: ['SGD', 'MYR', 'THB', 'IDR', 'PHP', 'VND', 'MMK', 'KHR', 'LAK', 'BND'] },
+  { region: 'southAsia', codes: ['INR', 'PKR', 'BDT', 'LKR', 'NPR', 'BTN', 'MVR', 'AFN'] },
+  { region: 'centralAsia', codes: ['KZT', 'UZS', 'TJS', 'TMT', 'KGS'] },
+  { region: 'middleEast', codes: ['AED', 'SAR', 'ILS', 'TRY', 'QAR', 'KWD', 'BHD', 'OMR', 'JOD', 'LBP', 'IQD', 'IRR', 'YER', 'SYP', 'GEL', 'AMD', 'AZN'] },
+  { region: 'europe', codes: ['EUR', 'GBP', 'CHF', 'SEK', 'NOK', 'DKK', 'PLN', 'CZK', 'HUF', 'RUB', 'BYN', 'UAH', 'RON', 'BGN', 'RSD', 'ISK', 'MDL', 'ALL', 'MKD', 'BAM', 'GIP'] },
   { region: 'northAmerica', codes: ['USD', 'CAD', 'MXN'] },
-  { region: 'southAmerica', codes: ['BRL', 'ARS', 'CLP', 'COP', 'PEN'] },
-  { region: 'oceania', codes: ['AUD', 'NZD'] },
-  { region: 'africa', codes: ['ZAR', 'EGP', 'NGN'] },
+  { region: 'centralAmericaCaribbean', codes: ['GTQ', 'HNL', 'NIO', 'CRC', 'PAB', 'DOP', 'CUP', 'JMD', 'TTD', 'BSD', 'BBD', 'BZD', 'HTG', 'XCD', 'KYD', 'AWG', 'ANG', 'BMD'] },
+  { region: 'southAmerica', codes: ['BRL', 'ARS', 'CLP', 'COP', 'PEN', 'UYU', 'PYG', 'BOB', 'VES', 'GYD', 'SRD'] },
+  { region: 'oceania', codes: ['AUD', 'NZD', 'FJD', 'PGK', 'SBD', 'TOP', 'VUV', 'WST', 'XPF'] },
+  { region: 'africa', codes: ['ZAR', 'EGP', 'NGN', 'KES', 'GHS', 'MAD', 'DZD', 'TND', 'LYD', 'ETB', 'UGX', 'TZS', 'RWF', 'XAF', 'XOF', 'MUR', 'BWP', 'NAD', 'ZMW', 'MWK', 'MZN', 'AOA', 'CDF', 'GMD', 'GNF', 'LRD', 'SLE', 'SDG', 'SSP', 'SOS', 'DJF', 'ERN', 'BIF', 'CVE', 'STN', 'SCR', 'KMF', 'LSL', 'SZL', 'MGA', 'MRU'] },
 ]
 
 export const CURRENCY_CODES: readonly string[] = CURRENCY_GROUPS.flatMap((g) => g.codes)
 
 export const CURRENCY_REGION_GROUPS = CURRENCY_GROUPS
+
+/**
+ * 用 [Intl.DisplayNames] 按 locale 本地化任意 ISO 货币名(en→"US Dollar",
+ * zh-CN→"美元")。环境不支持 / 未知 code 时回退 code 本身。
+ *
+ * 组件层优先用 i18n key `currency.<CODE>` 覆盖(主流币种保留人工译名),
+ * 仅在无覆盖时调用本函数 —— 这样长尾币种也能自动按当前语言显示名称。
+ */
+export function currencyDisplayName(code: string, locale: string): string {
+  const upper = code.toUpperCase()
+  try {
+    const dn = new Intl.DisplayNames([locale], { type: 'currency' })
+    return dn.of(upper) || upper
+  } catch {
+    return upper
+  }
+}


### PR DESCRIPTION
配合 App 端补齐币种(TNT-Likely/BeeCount#273)。

## 改动
- 币种列表与 App 对齐到 **151 种**(全量 ISO 4217,含 KES / XAF / XOF 等),新增 `centralAmericaCaribbean` 地区分组。
- 币种名称改用 `Intl.DisplayNames` 按当前语言本地化**任意**币种(en→"US Dollar"、zh→"美元");主流币种仍由 `currency.<CODE>` i18n key 覆盖,保留人工译名。搜索同时匹配 code 与本地化名。
- **server 零改动**。

## 测试
- 新增 `apps/web/src/currencies.test.ts`:数量 / 去重 / Intl 本地化(en + zh-CN) / 未知 code 回退,全量 **58 测试通过**。
- `tsc -b` + `vite build` 通过。