### PR TITLE
feat(ai-config): #357 透传 audioMode 与深度思考字段

### DIFF
--- a/frontend/apps/web/src/components/ai-config/ProviderEditDialog.tsx
+++ b/frontend/apps/web/src/components/ai-config/ProviderEditDialog.tsx
@@ -77,6 +77,7 @@ export function ProviderEditDialog({ open, initial, saving = false, onClose, onS
   // 当前 form 拼出来的 provider snapshot —— 测试按钮用,允许"先填再测再存"
   const draftProvider = useMemo<AIProvider>(
     () => ({
+      ...(initial ?? {}),
       id: initial?.id || 'draft',
       name: name.trim(),
       isBuiltIn,
@@ -106,6 +107,7 @@ export function ProviderEditDialog({ open, initial, saving = false, onClose, onS
         ? crypto.randomUUID()
         : `prov_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`)
     const next: AIProvider = {
+      ...(initial ?? {}),
       id,
       name: name.trim(),
       isBuiltIn,

--- a/frontend/apps/web/src/lib/aiConfigMerge.test.ts
+++ b/frontend/apps/web/src/lib/aiConfigMerge.test.ts
@@ -106,25 +106,18 @@ describe('mergeAiConfig', () => {
     expect(next.providers).toHaveLength(1)
   })
 
-  it('preserves audioMode and reasoning when patch only changes binding', () => {
+  it('preserves audio_mode and reasoning when patch only changes binding', () => {
     const current = {
-      providers: [
-        {
-          id: 'a',
-          name: 'A',
-          audioMode: 'multimodal_chat',
-        },
-      ],
+      providers: [{ id: 'a', name: 'A' }],
       binding: { speechProviderId: 'a' },
+      audio_mode: 'multimodal_chat',
       ai_reasoning_level: 'low',
-      ai_reasoning_vendor: 'volcengine',
     }
     const next = mergeAiConfig(current, {
       binding: { speechProviderId: 'a', textProviderId: 'a' },
     }) as Record<string, any>
-    expect(next.providers[0].audioMode).toBe('multimodal_chat')
+    expect(next.audio_mode).toBe('multimodal_chat')
     expect(next.ai_reasoning_level).toBe('low')
-    expect(next.ai_reasoning_vendor).toBe('volcengine')
   })
 
   it('does NOT add default ai_reasoning_level when current lacks it', () => {
@@ -133,7 +126,7 @@ describe('mergeAiConfig', () => {
       providers: [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }],
     }) as Record<string, any>
     expect('ai_reasoning_level' in next).toBe(false)
-    expect('ai_reasoning_vendor' in next).toBe(false)
+    expect('audio_mode' in next).toBe(false)
     expect('voice_trigger_mode' in next).toBe(false)
   })
 

--- a/frontend/apps/web/src/lib/aiConfigMerge.test.ts
+++ b/frontend/apps/web/src/lib/aiConfigMerge.test.ts
@@ -105,6 +105,43 @@ describe('mergeAiConfig', () => {
     expect(next.another_unknown).toEqual({ nested: true })
     expect(next.providers).toHaveLength(1)
   })
+
+  it('preserves audioMode and reasoning when patch only changes binding', () => {
+    const current = {
+      providers: [
+        {
+          id: 'a',
+          name: 'A',
+          audioMode: 'multimodal_chat',
+        },
+      ],
+      binding: { speechProviderId: 'a' },
+      ai_reasoning_level: 'low',
+      ai_reasoning_vendor: 'volcengine',
+    }
+    const next = mergeAiConfig(current, {
+      binding: { speechProviderId: 'a', textProviderId: 'a' },
+    }) as Record<string, any>
+    expect(next.providers[0].audioMode).toBe('multimodal_chat')
+    expect(next.ai_reasoning_level).toBe('low')
+    expect(next.ai_reasoning_vendor).toBe('volcengine')
+  })
+
+  it('does NOT add default ai_reasoning_level when current lacks it', () => {
+    const current = { providers: [{ id: 'a', name: 'A' }], binding: {} }
+    const next = mergeAiConfig(current, {
+      providers: [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }],
+    }) as Record<string, any>
+    expect('ai_reasoning_level' in next).toBe(false)
+    expect('ai_reasoning_vendor' in next).toBe(false)
+    expect('voice_trigger_mode' in next).toBe(false)
+  })
+
+  it('merges empty current without crash (old config compat)', () => {
+    const next = mergeAiConfig({}, { binding: { textProviderId: 'zhipu_glm' } })
+    expect(next.binding).toEqual({ textProviderId: 'zhipu_glm' })
+    expect(next.providers).toEqual([])
+  })
 })
 
 describe('applyDeleteFallback', () => {

--- a/frontend/apps/web/src/lib/aiConfigMerge.ts
+++ b/frontend/apps/web/src/lib/aiConfigMerge.ts
@@ -20,7 +20,7 @@ import { BUILTIN_PROVIDER_ID } from '@beecount/api-client'
  *  - 只对 web 管的字段(providers / binding)给默认值兜底
  *  - **不**给 mobile-only 字段(custom_prompt / strategy / bill_extraction_enabled
  *    / use_vision / voice_trigger_mode / voice_silence_timeout_ms /
- *    ai_reasoning_level / ai_reasoning_vendor)写默认值 —— 否则 current 没有这字段时,
+ *    audio_mode / ai_reasoning_level)写默认值 —— 否则 current 没有这字段时,
  *    我们写 `''` 或 `false` 会通过 PATCH 推到 server,server 广播给 mobile,
  *    **mobile applyFromServer 会把本地真实值覆盖成空**。
  *

--- a/frontend/apps/web/src/lib/aiConfigMerge.ts
+++ b/frontend/apps/web/src/lib/aiConfigMerge.ts
@@ -19,10 +19,10 @@ import { BUILTIN_PROVIDER_ID } from '@beecount/api-client'
  *  - `...(current ?? {})` spread 让所有现有字段(含未来 mobile 加的)透传保留
  *  - 只对 web 管的字段(providers / binding)给默认值兜底
  *  - **不**给 mobile-only 字段(custom_prompt / strategy / bill_extraction_enabled
- *    / use_vision)写默认值 —— 否则 current 没有这字段时,我们写 `''` 或 `false`
- *    会通过 PATCH 推到 server,server 广播给 mobile,**mobile applyFromServer
- *    会把本地真实值覆盖成空**。曾经触发过 mobile 端用户 prompt 被 web 端清掉
- *    的回归。
+ *    / use_vision / voice_trigger_mode / voice_silence_timeout_ms /
+ *    ai_reasoning_level / ai_reasoning_vendor)写默认值 —— 否则 current 没有这字段时,
+ *    我们写 `''` 或 `false` 会通过 PATCH 推到 server,server 广播给 mobile,
+ *    **mobile applyFromServer 会把本地真实值覆盖成空**。
  *
  *    判断规则:仅在 patch 显式传入时才写;否则交给 ...current spread 透传(有
  *    就保留,没有就保持没有)。

--- a/frontend/packages/api-client/src/types.ts
+++ b/frontend/packages/api-client/src/types.ts
@@ -58,8 +58,6 @@ export type AIProvider = {
   textModel?: string
   visionModel?: string
   audioModel?: string
-  /** 语音识别模式：transcription | multimodal_chat（mobile-only，透传） */
-  audioMode?: string
   createdAt?: string // ISO 8601
 }
 
@@ -84,10 +82,10 @@ export type AIConfig = {
   voice_trigger_mode?: string
   /** mobile-only：自动检测静音阈值（毫秒） */
   voice_silence_timeout_ms?: number
+  /** mobile-only：语音识别模式 transcription | multimodal_chat */
+  audio_mode?: string
   /** mobile-only：深度思考档位 off | low | medium | high */
   ai_reasoning_level?: string
-  /** mobile-only：深度思考厂商协议 none | volcengine | zhipu | openai_compat */
-  ai_reasoning_vendor?: string
 }
 
 /** 内置「智谱GLM」provider id —— 跟 mobile `zhipuDefault.id` 对齐,删除 fallback 用。 */

--- a/frontend/packages/api-client/src/types.ts
+++ b/frontend/packages/api-client/src/types.ts
@@ -58,6 +58,8 @@ export type AIProvider = {
   textModel?: string
   visionModel?: string
   audioModel?: string
+  /** 语音识别模式：transcription | multimodal_chat（mobile-only，透传） */
+  audioMode?: string
   createdAt?: string // ISO 8601
 }
 
@@ -78,6 +80,14 @@ export type AIConfig = {
   strategy?: string
   bill_extraction_enabled?: boolean
   use_vision?: boolean
+  /** mobile-only：语音触发方式 auto | hold_to_talk */
+  voice_trigger_mode?: string
+  /** mobile-only：自动检测静音阈值（毫秒） */
+  voice_silence_timeout_ms?: number
+  /** mobile-only：深度思考档位 off | low | medium | high */
+  ai_reasoning_level?: string
+  /** mobile-only：深度思考厂商协议 none | volcengine | zhipu | openai_compat */
+  ai_reasoning_vendor?: string
 }
 
 /** 内置「智谱GLM」provider id —— 跟 mobile `zhipuDefault.id` 对齐,删除 fallback 用。 */


### PR DESCRIPTION
## 关联

配合 [BeeCount #379](https://github.com/TNT-Likely/BeeCount/pull/379)（#357 多模态语音 + 全局深度思考）。

App 端 mobile-only 配置字段，Web 端需透传且**不能**在 merge/PATCH 时写入默认值，否则会把 App 本地真实值覆盖为空（历史上 `custom_prompt` 等字段曾因此回归）。

## 变更摘要

### 类型扩展（`packages/api-client/src/types.ts`）

- `AIConfig` 新增/调整 mobile-only 透传字段：
  - `voice_trigger_mode` / `voice_silence_timeout_ms`
  - `audio_mode`（`transcription` | `multimodal_chat`，**顶层全局**，已从 per-provider 挪出）
  - `ai_reasoning_level`（`off` | `low` | `medium` | `high`，**仅档位**）
- 移除 `AIProvider.audioMode` 与 `ai_reasoning_vendor`（与 App 设计调整对齐）

### merge 行为（`aiConfigMerge.ts`）

- 文档明确 mobile-only 字段列表，仅在 patch 显式传入时写入
- `...(current ?? {})` spread 保留 App 下发的未知/扩展字段

### ProviderEditDialog

- 草稿快照与保存时 `...(initial ?? {})`，编辑 provider 不丢失未来 per-provider 扩展字段

## 测试结果

```bash
pnpm -C apps/web test
# Test Files  8 passed (8)
# Tests       61 passed (61)
```

新增 `aiConfigMerge` 用例：
- 仅改 binding 时保留 `audio_mode` 与 `ai_reasoning_level`
- current 无 reasoning/audio 字段时不注入默认值
- 空配置 merge 不崩溃（老配置兼容）

## 部署说明

- 无后端 schema 变更（`ai_config` 本身为 dict 透传）
- 建议与 BeeCount App PR 同版本发布；**Cloud 可先合**（老 Web 对未知顶层字段本就用 spread 透传）

## Checklist

- [x] 单测通过
- [x] 不为 mobile-only 字段写默认值
- [x] 与 App #379 最新设计对齐（audio_mode 顶层、无 vendor 轴）
- [ ] Maintainer review