### PR TITLE
fix: use TencentCOS provider for Tencent COS

### DIFF
--- a/frontend/packages/web-features/src/features/BackupRemotesPanel.tsx
+++ b/frontend/packages/web-features/src/features/BackupRemotesPanel.tsx
@@ -70,7 +70,7 @@ const S3_PROVIDERS: Array<{ value: string; label: string }> = [
   { value: 'AWS', label: 'AWS' },
   { value: 'Cloudflare', label: 'Cloudflare R2' },
   { value: 'Alibaba', label: '阿里云 OSS' },
-  { value: 'Tencent', label: '腾讯云 COS' },
+  { value: 'TencentCOS', label: '腾讯云 COS' },
   { value: 'Backblaze', label: 'Backblaze B2 (S3 API)' },
   { value: 'Wasabi', label: 'Wasabi' },
   { value: 'DigitalOcean', label: 'DigitalOcean Spaces' },
@@ -109,7 +109,7 @@ const BACKEND_FIELDS: Record<string, FieldSpec[]> = {
       hint: 'R2:https://<account-id>.r2.cloudflarestorage.com。AWS 留空(自动选 region)。MinIO:你的服务器地址。',
       showWhen: {
         key: 'provider',
-        equals: ['Cloudflare', 'Alibaba', 'Tencent', 'Wasabi', 'DigitalOcean', 'Minio', 'IBMCOS', 'Other'],
+        equals: ['Cloudflare', 'Alibaba', 'TencentCOS', 'Wasabi', 'DigitalOcean', 'Minio', 'IBMCOS', 'Other'],
       },
     },
   ],


### PR DESCRIPTION
rclone 需要 "TencentCOS"，现在项目里面是"Tencent"


```
2026/07/23 17:44:13 DEBUG : rclone: Version "v1.60.1-DEV" starting with parameters ["rclone" "--config" "/path/to/rclone.conf" "lsd" "my-remote:my-bucket-1234567890" "--max-depth" "1" "-vv"]
2026/07/23 17:44:13 DEBUG : Creating backend with remote "my-remote:my-bucket-1234567890"
2026/07/23 17:44:13 DEBUG : Using config file from "/path/to/rclone.conf"
2026/07/23 17:44:13 NOTICE: s3: s3 provider "Tencent" not known - please set correctly
2026/07/23 17:44:14 ERROR : : error listing: PathStyleDomainForbidden: The bucket you are attempting to access must be addressed using COS virtual-styled domain. status code: 403, request id: <REQUEST_ID>, host id: 
2026/07/23 17:44:14 DEBUG : 4 go routines active
2026/07/23 17:44:14 Failed to lsd with 2 errors: last error was: PathStyleDomainForbidden: The bucket you are attempting to access must be addressed using COS virtual-styled domain. status code: 403, request id: <REQUEST_ID>, host id:
```