### PR TITLE
fix: 校验共享交易的 Owner 标签归属

### DIFF
--- a/src/projection.py
+++ b/src/projection.py
@@ -33,6 +33,50 @@ from .models import (
 
 logger = logging.getLogger(__name__)
 
+_DEFER_ATTACHMENT_UNLINKS = "defer_attachment_unlinks"
+_PENDING_ATTACHMENT_UNLINKS = "pending_attachment_unlinks"
+
+
+def defer_attachment_unlinks(db: Session) -> None:
+    """把本 Session 的附件物理删除延迟到调用方确认 commit 成功后。
+
+    数据库 rollback 能恢复 ``AttachmentFile`` 行，却无法恢复已经 unlink 的
+    文件。需要整批原子语义的入口（目前是 mobile sync push）在开始处理前调用
+    本函数，并在成功 commit 后调用 :func:`flush_deferred_attachment_unlinks`。
+    若事务抛错，Session 关闭即可丢弃队列，物理文件保持不变。
+    """
+    db.info[_DEFER_ATTACHMENT_UNLINKS] = True
+    db.info.setdefault(_PENDING_ATTACHMENT_UNLINKS, set())
+
+
+def flush_deferred_attachment_unlinks(db: Session) -> None:
+    """在数据库 commit 成功后执行本 Session 排队的附件物理删除。"""
+    paths = db.info.pop(_PENDING_ATTACHMENT_UNLINKS, set())
+    db.info.pop(_DEFER_ATTACHMENT_UNLINKS, None)
+    for storage_path in paths:
+        _unlink_attachment_path(storage_path)
+
+
+def _unlink_or_defer_attachment(db: Session, storage_path: str) -> None:
+    if db.info.get(_DEFER_ATTACHMENT_UNLINKS):
+        pending = db.info.setdefault(_PENDING_ATTACHMENT_UNLINKS, set())
+        pending.add(storage_path)
+        return
+    _unlink_attachment_path(storage_path)
+
+
+def _unlink_attachment_path(storage_path: str) -> None:
+    try:
+        path = Path(storage_path)
+        if path.exists():
+            path.unlink()
+    except OSError as exc:
+        logger.warning(
+            "attachment gc unlink failed path=%s err=%s",
+            storage_path,
+            exc,
+        )
+
 
 # --------------------------------------------------------------------------- #
 # Payload 字段提取                                                              #
@@ -902,15 +946,7 @@ def gc_orphan_attachments_for_ledger(
         storage_path = att.storage_path
         db.delete(att)
 
-        try:
-            p = Path(storage_path)
-            if p.exists():
-                p.unlink()
-        except OSError as exc:
-            logger.warning(
-                "attachment gc unlink failed ledger=%s file=%s path=%s err=%s",
-                ledger_id, file_id, storage_path, exc,
-            )
+        _unlink_or_defer_attachment(db, storage_path)
 
         cleaned += 1
 
@@ -967,17 +1003,7 @@ def gc_orphan_attachments(
         storage_path = att.storage_path
         db.delete(att)
 
-        # Best-effort unlink。DB 提交失败时这里改不回来,但事务 rollback 后
-        # AttachmentFile 行还在,下次 GC 再来。
-        try:
-            p = Path(storage_path)
-            if p.exists():
-                p.unlink()
-        except OSError as exc:
-            logger.warning(
-                "attachment gc unlink failed user=%s file=%s path=%s err=%s",
-                user_id, file_id, storage_path, exc,
-            )
+        _unlink_or_defer_attachment(db, storage_path)
 
         cleaned += 1
 

--- a/src/routers/import_data/endpoints.py
+++ b/src/routers/import_data/endpoints.py
@@ -42,6 +42,11 @@ from ...services.import_data import (
 )
 from ...services.import_data.cache import save_token_data, update_token
 from ...services.import_data.stats import build_existing_sets, compute_stats
+from ...services.transaction_tags import (
+    SharedTransactionTagError,
+    is_shared_ledger,
+    resolve_owner_transaction_tag_names,
+)
 from ...snapshot_mutator import (
     create_account,
     create_category,
@@ -421,8 +426,52 @@ async def _do_execute(
     existing_account_names, existing_category_keys, existing_tag_names, existing_dedup = build_existing_sets(snapshot)
 
     actor_payload_base = _payload_with_actor({}, _user_stub(user_id))
+    all_tag_names = _collect_new_tags(txs, auto_tags, existing_tag_names)
+    requested_tag_names = list(
+        dict.fromkeys(
+            name.strip()
+            for source in (auto_tags, *(tx.tag_names for tx in txs))
+            for name in source
+            if name.strip()
+        )
+    )
+    tag_name_to_sync_id: dict[str, str] = {}
+    for tag in snapshot.get("tags") or []:
+        name = str(tag.get("name") or "").strip()
+        sync_id = str(tag.get("syncId") or "").strip()
+        if name and sync_id:
+            tag_name_to_sync_id.setdefault(name, sync_id)
 
     try:
+        if is_shared_ledger(db, ledger) and requested_tag_names:
+            try:
+                owner_tags, missing_names = resolve_owner_transaction_tag_names(
+                    db,
+                    ledger=ledger,
+                    names=requested_tag_names,
+                )
+            except SharedTransactionTagError as exc:
+                raise _ImportFailed(
+                    code=exc.code,
+                    row_number=0,
+                    field_name="tag",
+                    message=exc.message,
+                    raw_line="",
+                ) from exc
+            for name, row in owner_tags.items():
+                tag_name_to_sync_id[name] = row.sync_id
+            if user_id != ledger.user_id and missing_names:
+                raise _ImportFailed(
+                    code="SHARED_TX_TAG_NOT_OWNER",
+                    row_number=0,
+                    field_name="tag",
+                    message=(
+                        "Unknown shared transaction tags must be created by the "
+                        f"ledger owner first: {', '.join(missing_names)}"
+                    ),
+                    raw_line="",
+                )
+
         # 1. accounts
         account_diff_names = _collect_new_accounts(txs, existing_account_names)
         for i, name in enumerate(account_diff_names, 1):
@@ -472,12 +521,12 @@ async def _do_execute(
             )
 
         # 3. tags(包括 auto_tags)
-        all_tag_names = _collect_new_tags(txs, auto_tags, existing_tag_names)
         for i, name in enumerate(all_tag_names, 1):
             try:
-                snapshot, _ = create_tag(
+                snapshot, new_tag_id = create_tag(
                     snapshot, {**actor_payload_base, "name": name}
                 )
+                tag_name_to_sync_id[name] = new_tag_id
             except (KeyError, ValueError, PermissionError) as exc:
                 raise _ImportFailed(
                     code="WRITE_TAG_FAILED",
@@ -503,7 +552,12 @@ async def _do_execute(
                 skipped += 1
             else:
                 seen_keys.add(dedup_key)
-                tx_payload = _build_tx_payload(tx, auto_tags, actor_payload_base)
+                tx_payload = _build_tx_payload(
+                    tx,
+                    auto_tags,
+                    actor_payload_base,
+                    tag_name_to_sync_id,
+                )
                 try:
                     snapshot, _ = create_transaction(snapshot, tx_payload)
                 except (KeyError, ValueError, PermissionError) as exc:
@@ -814,9 +868,17 @@ def _collect_new_tags(txs, auto_tags: list[str], existing: set[str]) -> list[str
     return seen
 
 
-def _build_tx_payload(tx, auto_tags: list[str], actor_base: dict) -> dict:
-    user_tags = list(tx.tag_names)
-    merged = user_tags + [t for t in auto_tags if t and t not in user_tags]
+def _build_tx_payload(
+    tx,
+    auto_tags: list[str],
+    actor_base: dict,
+    tag_name_to_sync_id: dict[str, str] | None = None,
+) -> dict:
+    user_tags = list(dict.fromkeys(t.strip() for t in tx.tag_names if t.strip()))
+    normalized_auto = [
+        t.strip() for t in auto_tags if t.strip() and t.strip() not in user_tags
+    ]
+    merged = user_tags + list(dict.fromkeys(normalized_auto))
     payload = {
         **actor_base,
         "tx_type": tx.tx_type,
@@ -836,4 +898,12 @@ def _build_tx_payload(tx, auto_tags: list[str], actor_base: dict) -> dict:
     }
     if merged:
         payload["tags"] = merged
+        if tag_name_to_sync_id:
+            tag_ids = [
+                tag_name_to_sync_id[name]
+                for name in merged
+                if name in tag_name_to_sync_id
+            ]
+            if tag_ids:
+                payload["tag_ids"] = list(dict.fromkeys(tag_ids))
     return payload

--- a/src/routers/sync/push.py
+++ b/src/routers/sync/push.py
@@ -8,7 +8,13 @@ from __future__ import annotations
 
 from ...services.transaction_tags import (
     SharedTransactionTagError,
+    is_shared_ledger,
+    load_owner_transaction_tags,
     normalize_shared_transaction_tags,
+)
+from ...projection import (
+    defer_attachment_unlinks,
+    flush_deferred_attachment_unlinks,
 )
 from ._shared import *  # noqa: F401,F403 — 拉取所有 imports / helpers / router / constants
 
@@ -42,6 +48,12 @@ async def push_changes(
     conflict_samples: list[dict[str, Any]] = []
     max_cursor = 0
     touched_ledgers: dict[str, str] = {}
+    shared_ledger_cache: dict[str, bool] = {}
+    owner_tag_rows_cache: dict[str, list[Any]] = {}
+    locked_ledgers: set[str] = set()
+    # DB rollback 无法恢复已 unlink 的附件。整批成功 commit 后才真正删除文件；
+    # 任一 change 抛错时 Session 关闭并丢弃待删队列，保持 DB/磁盘一致。
+    defer_attachment_unlinks(db)
     # 共享账本 Phase 1:user-global category/account/tag 变更要 fan-out 给
     # 该 user 作为 owner 的所有共享账本的非 owner member。收集后 commit 后广播。
     pending_shared_resource_events: list[dict[str, Any]] = []
@@ -112,36 +124,6 @@ async def push_changes(
                         "sync.push.reject ledger-meta change from non-owner "
                         "user=%s ledger=%s role=%s entity=%s",
                         current_user.id, change.ledger_id, caller_role, change.entity_type,
-                    )
-                    rejected += 1
-                    continue
-
-            # 共享账本交易只允许引用账本 Owner 的 user-global 标签。
-            # 老协议只有 tags(name)时可解析已有 Owner 标签；无法解析就拒绝该
-            # change，不能让 projection / pull fallback 在任一成员端创建新标签。
-            if (
-                change.entity_type == "transaction"
-                and change.action == "upsert"
-                and isinstance(change.payload, dict)
-            ):
-                try:
-                    normalize_shared_transaction_tags(
-                        db,
-                        ledger=ledger,
-                        payload=change.payload,
-                        tag_ids_key="tagIds",
-                        tags_as_list=False,
-                    )
-                except SharedTransactionTagError as exc:
-                    logger.warning(
-                        "sync.push.reject shared transaction tag user=%s "
-                        "ledger=%s sync_id=%s code=%s ids=%s names=%s",
-                        current_user.id,
-                        change.ledger_id,
-                        change.entity_sync_id,
-                        exc.code,
-                        exc.unknown_tag_ids,
-                        exc.unknown_tag_names,
                     )
                     rejected += 1
                     continue
@@ -249,6 +231,65 @@ async def push_changes(
             )
             continue
 
+        # 只校验实际会赢得 LWW、准备落库的新 change。若放在 replay/conflict
+        # 判断之前，Owner 后续重命名/删除标签会让完全相同的幂等重放反而失败。
+        #
+        # 标签校验失败必须让整批请求返回非 2xx：现有 mobile 收到任意 2xx 后会
+        # 把整批 local_changes 标成 pushed，若这里只累计 rejected 并继续，交易
+        # 未落库却会在客户端永久出队，形成静默数据丢失。抛 400 会回滚本批此前
+        # 尚未 commit 的变更，客户端也会保留本地 change 供用户修正后重试。
+        if (
+            not is_user_global
+            and change.entity_type == "transaction"
+            and change.action == "upsert"
+            and isinstance(change.payload, dict)
+        ):
+            assert ledger is not None
+            if ledger.id not in locked_ledgers:
+                lock_ledger_for_materialize(db, ledger.id)
+                locked_ledgers.add(ledger.id)
+            shared = shared_ledger_cache.get(ledger.id)
+            if shared is None:
+                shared = is_shared_ledger(db, ledger)
+                shared_ledger_cache[ledger.id] = shared
+            try:
+                owner_tag_rows = None
+                if shared and (
+                    "tags" in change.payload or "tagIds" in change.payload
+                ):
+                    owner_tag_rows = owner_tag_rows_cache.get(ledger.user_id)
+                    if owner_tag_rows is None:
+                        owner_tag_rows = load_owner_transaction_tags(
+                            db,
+                            ledger=ledger,
+                        )
+                        owner_tag_rows_cache[ledger.user_id] = owner_tag_rows
+                normalize_shared_transaction_tags(
+                    db,
+                    ledger=ledger,
+                    payload=change.payload,
+                    tag_ids_key="tagIds",
+                    tags_as_list=False,
+                    shared_ledger=shared,
+                    owner_tag_rows=owner_tag_rows,
+                )
+            except SharedTransactionTagError as exc:
+                logger.warning(
+                    "sync.push.reject shared transaction tag user=%s "
+                    "ledger=%s sync_id=%s code=%s ids=%s names=%s ambiguous=%s",
+                    current_user.id,
+                    change.ledger_id,
+                    change.entity_sync_id,
+                    exc.code,
+                    exc.unknown_tag_ids,
+                    exc.unknown_tag_names,
+                    exc.ambiguous_tag_names,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=exc.as_detail(),
+                ) from exc
+
         # ============================================================
         # SyncChange row + apply 路径
         # ============================================================
@@ -294,6 +335,10 @@ async def push_changes(
                     "sync_id": change.entity_sync_id,
                     "payload": change.payload or {"sync_id": change.entity_sync_id},
                 })
+            if change.entity_type == "tag":
+                # 同一 push 可先创建/重命名 Owner 标签、再写交易。清缓存让后续
+                # 交易看到刚刚 materialize 的最新标签集合。
+                owner_tag_rows_cache.pop(current_user.id, None)
         else:
             assert ledger is not None
             # §7 共享账本:mobile 历史路径未在本地 transactions.created_by_user_id
@@ -337,7 +382,9 @@ async def push_changes(
             # 方案 B:projection 随 push 同事务刷新。不再写 ledger_snapshot 行。
             if change.entity_type in INDIVIDUAL_ENTITY_TYPES:
                 # lock 一次/账本,避免两个 push 并发走同个 ledger 的 cascade
-                lock_ledger_for_materialize(db, ledger.id)
+                if ledger.id not in locked_ledgers:
+                    lock_ledger_for_materialize(db, ledger.id)
+                    locked_ledgers.add(ledger.id)
                 try:
                     apply_change_to_projection(
                         db,
@@ -379,6 +426,7 @@ async def push_changes(
         max_cursor = _max_cursor_for_ledgers(db, [lg.id for lg in accessible])
 
     db.commit()
+    flush_deferred_attachment_unlinks(db)
 
     if touched_ledgers:
         ws_manager = request.app.state.ws_manager

--- a/src/routers/sync/push.py
+++ b/src/routers/sync/push.py
@@ -6,7 +6,12 @@
 """
 from __future__ import annotations
 
+from ...services.transaction_tags import (
+    SharedTransactionTagError,
+    normalize_shared_transaction_tags,
+)
 from ._shared import *  # noqa: F401,F403 — 拉取所有 imports / helpers / router / constants
+
 
 @router.post("/push", response_model=SyncPushResponse)
 async def push_changes(
@@ -107,6 +112,36 @@ async def push_changes(
                         "sync.push.reject ledger-meta change from non-owner "
                         "user=%s ledger=%s role=%s entity=%s",
                         current_user.id, change.ledger_id, caller_role, change.entity_type,
+                    )
+                    rejected += 1
+                    continue
+
+            # 共享账本交易只允许引用账本 Owner 的 user-global 标签。
+            # 老协议只有 tags(name)时可解析已有 Owner 标签；无法解析就拒绝该
+            # change，不能让 projection / pull fallback 在任一成员端创建新标签。
+            if (
+                change.entity_type == "transaction"
+                and change.action == "upsert"
+                and isinstance(change.payload, dict)
+            ):
+                try:
+                    normalize_shared_transaction_tags(
+                        db,
+                        ledger=ledger,
+                        payload=change.payload,
+                        tag_ids_key="tagIds",
+                        tags_as_list=False,
+                    )
+                except SharedTransactionTagError as exc:
+                    logger.warning(
+                        "sync.push.reject shared transaction tag user=%s "
+                        "ledger=%s sync_id=%s code=%s ids=%s names=%s",
+                        current_user.id,
+                        change.ledger_id,
+                        change.entity_sync_id,
+                        exc.code,
+                        exc.unknown_tag_ids,
+                        exc.unknown_tag_names,
                     )
                     rejected += 1
                     continue
@@ -422,5 +457,3 @@ async def push_changes(
         server_cursor=max_cursor,
         server_timestamp=now,
     )
-
-

--- a/src/routers/write/_shared.py
+++ b/src/routers/write/_shared.py
@@ -541,6 +541,7 @@ async def _commit_create_tx_fast(
     device_id: str,
     audit_action: str,
     mutate_payload: dict,
+    precommit_validate: Callable[[], None] | None = None,
 ) -> WriteCommitMeta:
     """Fast path:新建单笔 tx,跳过全量 snapshot build(issue #31 A1b)。
 
@@ -558,6 +559,8 @@ async def _commit_create_tx_fast(
     def _core() -> tuple[WriteCommitMeta, bool]:
         """同步 DB 核心,返回 (response, did_replay)。在 worker thread 里跑。"""
         lock_ledger_for_materialize(db, ledger.id)
+        if precommit_validate is not None:
+            precommit_validate()
         now = _utcnow()
         # 空 snapshot 跑 mutator —— 只为复用其字段规范化 + actor 标记逻辑。
         _snap, tx_id = _mutate_create_tx({"items": [], "count": 0}, mutate_payload)
@@ -676,6 +679,7 @@ async def _commit_write_fast_tx(
     tx_id: str,
     mutate_payload: dict,
     action: str,  # "upsert" | "delete"
+    precommit_validate: Callable[[], None] | None = None,
 ) -> WriteCommitMeta:
     """Fast path:单 tx update/delete,跳过全 snapshot build。只 SELECT 目标 tx
     (1 条 query by PK)→ 合并 payload → 写 SyncChange + projection。~10-15ms。
@@ -686,6 +690,8 @@ async def _commit_write_fast_tx(
     def _core() -> tuple[WriteCommitMeta, bool]:
         """同步 DB 核心,返回 (response, did_replay)。在 worker thread 里跑。"""
         lock_ledger_for_materialize(db, ledger.id)
+        if precommit_validate is not None:
+            precommit_validate()
         now = _utcnow()
 
         # 1. 读目标 tx from projection

--- a/src/routers/write/transactions.py
+++ b/src/routers/write/transactions.py
@@ -7,10 +7,37 @@ WRITE 响应表。Endpoint 自身只管参数校验 + mutate lambda 的构造。
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from sqlalchemy.orm import Session
 
+from ...models import Ledger
+from ...services.transaction_tags import (
+    SharedTransactionTagError,
+    normalize_shared_transaction_tags,
+)
 from ._shared import *  # noqa: F401,F403 — 集中从 _shared 取所有 symbol
 
 router = APIRouter()
+
+
+def _normalize_shared_tx_tags_or_400(
+    db: Session,
+    *,
+    ledger: Ledger,
+    payload: dict,
+) -> None:
+    try:
+        normalize_shared_transaction_tags(
+            db,
+            ledger=ledger,
+            payload=payload,
+            tag_ids_key="tag_ids",
+            tags_as_list=True,
+        )
+    except SharedTransactionTagError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=exc.as_detail(),
+        ) from exc
 
 
 @router.post(
@@ -29,6 +56,7 @@ async def create_tx(
     db: Session = Depends(get_db),
 ) -> WriteCommitMeta:
     payload = req.model_dump(mode="json")
+    request_payload = dict(payload)
     ledger, replay = _prepare_write(
         db=db,
         current_user=current_user,
@@ -38,10 +66,11 @@ async def create_tx(
         device_id=device_id,
         method=request.method,
         path=request.url.path,
-        payload=payload,
+        payload=request_payload,
     )
     if replay:
         return replay
+    _normalize_shared_tx_tags_or_400(db, ledger=ledger, payload=payload)
     # 旧架构这里要跑 _resolve_tx_dictionary_payload 去 UserAccount/Category/Tag
     # 三张投影表里查 id / 建 row。新架构所有实体都是 snapshot 里的 syncId,
     # web UI 下拉选项也从 snapshot 读,account_id / category_id / tag_ids 直接
@@ -55,7 +84,7 @@ async def create_tx(
         current_user=current_user,
         ledger=ledger,
         base_change_id=req.base_change_id,
-        request_payload=payload,
+        request_payload=request_payload,
         idempotency_key=idempotency_key,
         device_id=device_id,
         audit_action="web_tx_create",
@@ -80,6 +109,7 @@ async def update_tx(
     db: Session = Depends(get_db),
 ) -> WriteCommitMeta:
     payload = req.model_dump(mode="json", exclude_unset=True)
+    request_payload = dict(payload)
     ledger, replay = _prepare_write(
         db=db,
         current_user=current_user,
@@ -89,10 +119,11 @@ async def update_tx(
         device_id=device_id,
         method=request.method,
         path=request.url.path,
-        payload=payload,
+        payload=request_payload,
     )
     if replay:
         return replay
+    _normalize_shared_tx_tags_or_400(db, ledger=ledger, payload=payload)
     _assert_can_modify_entity(
         db=db,
         ledger=ledger,
@@ -108,7 +139,7 @@ async def update_tx(
         current_user=current_user,
         ledger=ledger,
         base_change_id=req.base_change_id,
-        request_payload=payload,
+        request_payload=request_payload,
         idempotency_key=idempotency_key,
         device_id=device_id,
         audit_action="web_tx_update",
@@ -169,5 +200,3 @@ async def delete_tx(
         mutate_payload=mutate_payload,
         action="delete",
     )
-
-

--- a/src/routers/write/transactions.py
+++ b/src/routers/write/transactions.py
@@ -70,7 +70,6 @@ async def create_tx(
     )
     if replay:
         return replay
-    _normalize_shared_tx_tags_or_400(db, ledger=ledger, payload=payload)
     # 旧架构这里要跑 _resolve_tx_dictionary_payload 去 UserAccount/Category/Tag
     # 三张投影表里查 id / 建 row。新架构所有实体都是 snapshot 里的 syncId,
     # web UI 下拉选项也从 snapshot 读,account_id / category_id / tag_ids 直接
@@ -89,6 +88,11 @@ async def create_tx(
         device_id=device_id,
         audit_action="web_tx_create",
         mutate_payload=mutate_payload,
+        precommit_validate=lambda: _normalize_shared_tx_tags_or_400(
+            db,
+            ledger=ledger,
+            payload=mutate_payload,
+        ),
     )
 
 
@@ -123,7 +127,6 @@ async def update_tx(
     )
     if replay:
         return replay
-    _normalize_shared_tx_tags_or_400(db, ledger=ledger, payload=payload)
     _assert_can_modify_entity(
         db=db,
         ledger=ledger,
@@ -146,6 +149,11 @@ async def update_tx(
         tx_id=tx_id,
         mutate_payload=mutate_payload,
         action="upsert",
+        precommit_validate=lambda: _normalize_shared_tx_tags_or_400(
+            db,
+            ledger=ledger,
+            payload=mutate_payload,
+        ),
     )
 
 

--- a/src/routers/write/transactions_batch.py
+++ b/src/routers/write/transactions_batch.py
@@ -41,6 +41,10 @@ from ...models import (
 )
 from ...security import SCOPE_APP_WRITE, SCOPE_WEB_WRITE
 from ...services.ai.image_cache import consume_image
+from ...services.transaction_tags import (
+    SharedTransactionTagError,
+    is_shared_ledger,
+)
 from ...snapshot_mutator import create_tag, create_transaction
 from ._shared import (
     _TRANSACTION_WRITE_ROLES,
@@ -195,6 +199,7 @@ async def create_tx_batch(
                 )
 
         snapshot = snapshot_builder.build(db, ledger)
+        shared_ledger = is_shared_ledger(db, ledger)
         prev_snapshot = {**snapshot}
         for _k in ("items", "accounts", "categories", "tags", "budgets"):
             arr = snapshot.get(_k)
@@ -219,6 +224,16 @@ async def create_tx_batch(
         for name in needed_names:
             if name in tag_name_to_sync_id and tag_name_to_sync_id[name]:
                 continue
+            if shared_ledger and current_user.id != ledger.user_id:
+                exc = SharedTransactionTagError(
+                    "SHARED_TX_TAG_NOT_OWNER",
+                    "Unknown shared transaction tags must be created by the ledger owner first",
+                    unknown_tag_names=[name],
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=exc.as_detail(),
+                )
             tag_payload = _payload_with_actor({"name": name}, current_user)
             try:
                 snapshot, new_sync_id = create_tag(snapshot, tag_payload)

--- a/src/routers/write/transactions_batch.py
+++ b/src/routers/write/transactions_batch.py
@@ -44,6 +44,7 @@ from ...services.ai.image_cache import consume_image
 from ...services.transaction_tags import (
     SharedTransactionTagError,
     is_shared_ledger,
+    resolve_owner_transaction_tag_names,
 )
 from ...snapshot_mutator import create_tag, create_transaction
 from ._shared import (
@@ -144,34 +145,7 @@ async def create_tx_batch(
         # 幂等回放 — 直接拿之前的 BatchCreateTxResponse
         return BatchCreateTxResponse(**replay.model_dump()) if hasattr(replay, "model_dump") else replay  # type: ignore[return-value]
 
-    # 1. (可选)attach_image_id → 转正式 attachment 一份
-    attachment_dict: dict | None = None
-    attachment_file_id: str | None = None
-    if req.attach_image_id:
-        cached = consume_image(image_id=req.attach_image_id, user_id=current_user.id)
-        if cached is None:
-            logger.warning(
-                "tx.batch image_id=%s not found / expired / user_id mismatch",
-                req.attach_image_id,
-            )
-        else:
-            af = _create_attachment_from_bytes(
-                db=db,
-                ledger=ledger,
-                user_id=current_user.id,
-                image_bytes=cached.image_bytes,
-                mime_type=cached.mime_type,
-            )
-            attachment_file_id = af.id
-            attachment_dict = {
-                "cloudFileId": af.id,
-                "fileName": af.file_name or "screenshot.jpg",
-                "mimeType": af.mime_type,
-                "sha256": af.sha256,
-                "sizeBytes": af.size_bytes,
-            }
-
-    # 2. 解析自动 tag(AI 记账 + 可选 extra_tag),lookup ledger 已有名 → 没命中走 locale 默认
+    # 1. 解析自动 tag(AI 记账 + 可选 extra_tag),lookup ledger 已有名 → 没命中走 locale 默认
     auto_tag_names: list[str] = []
     if req.auto_ai_tag:
         ai_tag = _resolve_or_make_ai_tag_name(db, ledger, req.locale)
@@ -216,10 +190,28 @@ async def create_tx_batch(
             if n:
                 tag_name_to_sync_id.setdefault(n, str(t.get("syncId") or ""))
 
-        needed_names: set[str] = {n for n in auto_tag_names if n}
+        needed_names: set[str] = {n.strip() for n in auto_tag_names if n.strip()}
         for _item in req.transactions:
             if _item.tags:
-                needed_names.update(t for t in _item.tags if t)
+                needed_names.update(t.strip() for t in _item.tags if t.strip())
+
+        # snapshot 里同名标签若有多个 syncId，setdefault 会依赖查询顺序随机选
+        # 一个。共享账本中统一走 Owner projection 检测歧义，并用权威 ID 覆盖
+        # snapshot map；未知名称仍只允许 Owner 在下方创建。
+        if shared_ledger and needed_names:
+            try:
+                owner_tags, _missing_names = resolve_owner_transaction_tag_names(
+                    db,
+                    ledger=ledger,
+                    names=list(needed_names),
+                )
+            except SharedTransactionTagError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=exc.as_detail(),
+                ) from exc
+            for name, row in owner_tags.items():
+                tag_name_to_sync_id[name] = row.sync_id
 
         for name in needed_names:
             if name in tag_name_to_sync_id and tag_name_to_sync_id[name]:
@@ -244,6 +236,38 @@ async def create_tx_batch(
                     if (t.get("name") or "").strip() == name:
                         tag_name_to_sync_id[name] = str(t.get("syncId") or "")
                         break
+
+        # 标签权限校验必须早于一次性图片缓存消费和磁盘写入。否则 Editor 的
+        # 未知标签返回 400 时，图片已从缓存删除且 rollback 只能回滚 DB，无法
+        # 恢复物理文件/缓存，用户修正标签后重试会静默丢附件。
+        attachment_dict: dict | None = None
+        attachment_file_id: str | None = None
+        if req.attach_image_id:
+            cached = consume_image(
+                image_id=req.attach_image_id,
+                user_id=current_user.id,
+            )
+            if cached is None:
+                logger.warning(
+                    "tx.batch image_id=%s not found / expired / user_id mismatch",
+                    req.attach_image_id,
+                )
+            else:
+                af = _create_attachment_from_bytes(
+                    db=db,
+                    ledger=ledger,
+                    user_id=current_user.id,
+                    image_bytes=cached.image_bytes,
+                    mime_type=cached.mime_type,
+                )
+                attachment_file_id = af.id
+                attachment_dict = {
+                    "cloudFileId": af.id,
+                    "fileName": af.file_name or "screenshot.jpg",
+                    "mimeType": af.mime_type,
+                    "sha256": af.sha256,
+                    "sizeBytes": af.size_bytes,
+                }
 
         # 5. 循环 mutate snapshot,创建 N 笔
         created_sync_ids: list[str] = []
@@ -407,8 +431,11 @@ def _build_tx_payload(
     if item.native_amount is not None:
         payload["native_amount"] = item.native_amount
     # 合并 auto_tag(LLM 已识别的 tags + 自动加的 AI 记账 / 图片记账)
-    user_tags = list(item.tags or [])
-    merged_tags = user_tags + [t for t in auto_tag_names if t and t not in user_tags]
+    user_tags = list(dict.fromkeys(t.strip() for t in (item.tags or []) if t.strip()))
+    normalized_auto_tags = [
+        t.strip() for t in auto_tag_names if t.strip() and t.strip() not in user_tags
+    ]
+    merged_tags = user_tags + list(dict.fromkeys(normalized_auto_tags))
     if merged_tags:
         payload["tags"] = merged_tags
         # 反查 sync_id 一起传 — 让 projection.tag_sync_ids_json 完整填充。

--- a/src/services/transaction_tags.py
+++ b/src/services/transaction_tags.py
@@ -1,0 +1,187 @@
+"""共享账本交易标签校验。
+
+标签是 user-global 实体；共享账本内只有 Owner 的标签能作为交易标签。这个
+模块把 Mobile sync 的 camelCase payload 和 Web write 的 snake_case payload
+收敛到同一条规则：
+
+- tag id 必须存在于账本 Owner 的 ``UserTagProjection``；
+- 只有标签名时，只允许解析已有 Owner 标签，不能隐式创建 Editor 标签；
+- id 与 name 同时存在时，以 Owner 标签 id 为准并回填规范名称。
+
+个人账本保持旧协议行为，不在这里做限制。
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..models import Ledger, LedgerMember, UserTagProjection
+
+
+class SharedTransactionTagError(ValueError):
+    """共享交易引用了非 Owner 标签。"""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        unknown_tag_ids: list[str] | None = None,
+        unknown_tag_names: list[str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.unknown_tag_ids = unknown_tag_ids or []
+        self.unknown_tag_names = unknown_tag_names or []
+
+    def as_detail(self) -> dict[str, Any]:
+        detail: dict[str, Any] = {
+            "error_code": self.code,
+            "message": self.message,
+        }
+        if self.unknown_tag_ids:
+            detail["unknown_tag_ids"] = self.unknown_tag_ids
+        if self.unknown_tag_names:
+            detail["unknown_tag_names"] = self.unknown_tag_names
+        return detail
+
+
+def is_shared_ledger(db: Session, ledger: Ledger) -> bool:
+    """账本存在 Owner 之外的成员时视为共享账本。"""
+    member = db.scalar(
+        select(LedgerMember.user_id)
+        .where(
+            LedgerMember.ledger_id == ledger.id,
+            LedgerMember.user_id != ledger.user_id,
+        )
+        .limit(1)
+    )
+    return member is not None
+
+
+def normalize_shared_transaction_tags(
+    db: Session,
+    *,
+    ledger: Ledger,
+    payload: dict[str, Any],
+    tag_ids_key: str,
+    tags_key: str = "tags",
+    tags_as_list: bool,
+) -> None:
+    """原地校验并规范化共享交易 payload 的标签字段。
+
+    ``tag_ids_key`` 用于兼容 Mobile 的 ``tagIds`` 与 Web 的 ``tag_ids``。
+    ``tags_as_list`` 决定规范名称写回 list(Web mutator)还是 CSV(Mobile sync)。
+    未共享的账本、以及不包含任何标签字段的 partial update，直接保持原样。
+    """
+    tags_present = tags_key in payload
+    ids_present = tag_ids_key in payload
+    if not tags_present and not ids_present:
+        return
+    if not is_shared_ledger(db, ledger):
+        return
+
+    names = _normalize_names(payload.get(tags_key))
+    tag_ids = _normalize_ids(payload.get(tag_ids_key))
+
+    if not names and not tag_ids:
+        # 显式清空时把两列一起清掉，避免只清 name 或只清 id 后残留半套引用。
+        payload[tags_key] = [] if tags_as_list else ""
+        payload[tag_ids_key] = []
+        return
+
+    if tag_ids:
+        rows = list(
+            db.scalars(
+                select(UserTagProjection).where(
+                    UserTagProjection.user_id == ledger.user_id,
+                    UserTagProjection.sync_id.in_(tag_ids),
+                )
+            ).all()
+        )
+        by_id = {row.sync_id: row for row in rows}
+        unknown_ids = [tag_id for tag_id in tag_ids if tag_id not in by_id]
+        if unknown_ids:
+            raise SharedTransactionTagError(
+                "SHARED_TX_TAG_NOT_OWNER",
+                "Shared transaction tags must belong to the ledger owner",
+                unknown_tag_ids=unknown_ids,
+            )
+        canonical_names = [
+            str(by_id[tag_id].name or "").strip() for tag_id in tag_ids
+        ]
+        if any(not name for name in canonical_names):
+            invalid_ids = [
+                tag_id
+                for tag_id, name in zip(tag_ids, canonical_names, strict=True)
+                if not name
+            ]
+            raise SharedTransactionTagError(
+                "SHARED_TX_TAG_NOT_OWNER",
+                "Shared transaction tags must reference named owner tags",
+                unknown_tag_ids=invalid_ids,
+            )
+    else:
+        rows = list(
+            db.scalars(
+                select(UserTagProjection).where(
+                    UserTagProjection.user_id == ledger.user_id,
+                    UserTagProjection.name.in_(names),
+                )
+            ).all()
+        )
+        by_name = {
+            str(row.name or "").strip(): row
+            for row in rows
+            if str(row.name or "").strip()
+        }
+        unknown_names = [name for name in names if name not in by_name]
+        if unknown_names:
+            raise SharedTransactionTagError(
+                "SHARED_TX_TAG_NOT_OWNER",
+                "Unknown shared transaction tags must be created by the ledger owner first",
+                unknown_tag_names=unknown_names,
+            )
+        tag_ids = [by_name[name].sync_id for name in names]
+        canonical_names = [str(by_name[name].name).strip() for name in names]
+
+    payload[tag_ids_key] = tag_ids
+    payload[tags_key] = canonical_names if tags_as_list else ",".join(canonical_names)
+
+
+def _normalize_names(raw: Any) -> list[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        values = raw.split(",")
+    elif isinstance(raw, list):
+        values = raw
+    else:
+        raise SharedTransactionTagError(
+            "SHARED_TX_TAG_INVALID_FORMAT",
+            "Shared transaction tags must be a string or list",
+        )
+    return _dedupe_non_empty(values)
+
+
+def _normalize_ids(raw: Any) -> list[str]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise SharedTransactionTagError(
+            "SHARED_TX_TAG_INVALID_FORMAT",
+            "Shared transaction tag IDs must be a list",
+        )
+    return _dedupe_non_empty(raw)
+
+
+def _dedupe_non_empty(values: list[Any]) -> list[str]:
+    result: list[str] = []
+    for raw in values:
+        value = str(raw).strip()
+        if value and value not in result:
+            result.append(value)
+    return result

--- a/src/services/transaction_tags.py
+++ b/src/services/transaction_tags.py
@@ -30,12 +30,14 @@ class SharedTransactionTagError(ValueError):
         *,
         unknown_tag_ids: list[str] | None = None,
         unknown_tag_names: list[str] | None = None,
+        ambiguous_tag_names: list[str] | None = None,
     ) -> None:
         super().__init__(message)
         self.code = code
         self.message = message
         self.unknown_tag_ids = unknown_tag_ids or []
         self.unknown_tag_names = unknown_tag_names or []
+        self.ambiguous_tag_names = ambiguous_tag_names or []
 
     def as_detail(self) -> dict[str, Any]:
         detail: dict[str, Any] = {
@@ -46,6 +48,8 @@ class SharedTransactionTagError(ValueError):
             detail["unknown_tag_ids"] = self.unknown_tag_ids
         if self.unknown_tag_names:
             detail["unknown_tag_names"] = self.unknown_tag_names
+        if self.ambiguous_tag_names:
+            detail["ambiguous_tag_names"] = self.ambiguous_tag_names
         return detail
 
 
@@ -70,6 +74,8 @@ def normalize_shared_transaction_tags(
     tag_ids_key: str,
     tags_key: str = "tags",
     tags_as_list: bool,
+    shared_ledger: bool | None = None,
+    owner_tag_rows: list[UserTagProjection] | None = None,
 ) -> None:
     """原地校验并规范化共享交易 payload 的标签字段。
 
@@ -81,7 +87,9 @@ def normalize_shared_transaction_tags(
     ids_present = tag_ids_key in payload
     if not tags_present and not ids_present:
         return
-    if not is_shared_ledger(db, ledger):
+    if shared_ledger is None:
+        shared_ledger = is_shared_ledger(db, ledger)
+    if not shared_ledger:
         return
 
     names = _normalize_names(payload.get(tags_key))
@@ -94,14 +102,16 @@ def normalize_shared_transaction_tags(
         return
 
     if tag_ids:
-        rows = list(
-            db.scalars(
-                select(UserTagProjection).where(
-                    UserTagProjection.user_id == ledger.user_id,
-                    UserTagProjection.sync_id.in_(tag_ids),
-                )
-            ).all()
-        )
+        rows = owner_tag_rows
+        if rows is None:
+            rows = list(
+                db.scalars(
+                    select(UserTagProjection).where(
+                        UserTagProjection.user_id == ledger.user_id,
+                        UserTagProjection.sync_id.in_(tag_ids),
+                    )
+                ).all()
+            )
         by_id = {row.sync_id: row for row in rows}
         unknown_ids = [tag_id for tag_id in tag_ids if tag_id not in by_id]
         if unknown_ids:
@@ -125,20 +135,12 @@ def normalize_shared_transaction_tags(
                 unknown_tag_ids=invalid_ids,
             )
     else:
-        rows = list(
-            db.scalars(
-                select(UserTagProjection).where(
-                    UserTagProjection.user_id == ledger.user_id,
-                    UserTagProjection.name.in_(names),
-                )
-            ).all()
+        by_name, unknown_names = resolve_owner_transaction_tag_names(
+            db,
+            ledger=ledger,
+            names=names,
+            owner_tag_rows=owner_tag_rows,
         )
-        by_name = {
-            str(row.name or "").strip(): row
-            for row in rows
-            if str(row.name or "").strip()
-        }
-        unknown_names = [name for name in names if name not in by_name]
         if unknown_names:
             raise SharedTransactionTagError(
                 "SHARED_TX_TAG_NOT_OWNER",
@@ -150,6 +152,67 @@ def normalize_shared_transaction_tags(
 
     payload[tag_ids_key] = tag_ids
     payload[tags_key] = canonical_names if tags_as_list else ",".join(canonical_names)
+
+
+def resolve_owner_transaction_tag_names(
+    db: Session,
+    *,
+    ledger: Ledger,
+    names: list[str],
+    owner_tag_rows: list[UserTagProjection] | None = None,
+) -> tuple[dict[str, UserTagProjection], list[str]]:
+    """按名称解析 Owner 标签，并拒绝同名多 ID 的歧义引用。
+
+    返回 ``(name -> row, missing_names)``，由调用方决定缺失名称是允许 Owner
+    创建，还是必须拒绝 Editor。歧义名称没有安全的 fallback：不同入口或不同
+    数据库执行计划可能选择不同 ``sync_id``，因此统一要求调用方改用明确 ID。
+    """
+    wanted = _dedupe_non_empty(names)
+    if not wanted:
+        return {}, []
+
+    rows = owner_tag_rows
+    if rows is None:
+        rows = list(
+            db.scalars(
+                select(UserTagProjection).where(
+                    UserTagProjection.user_id == ledger.user_id,
+                    UserTagProjection.name.in_(wanted),
+                )
+            ).all()
+        )
+    grouped: dict[str, list[UserTagProjection]] = {}
+    for row in rows:
+        name = str(row.name or "").strip()
+        if name:
+            grouped.setdefault(name, []).append(row)
+
+    ambiguous_names = [name for name in wanted if len(grouped.get(name, [])) > 1]
+    if ambiguous_names:
+        raise SharedTransactionTagError(
+            "SHARED_TX_TAG_AMBIGUOUS",
+            "Ambiguous shared transaction tag names require explicit owner tag IDs",
+            ambiguous_tag_names=ambiguous_names,
+        )
+
+    by_name = {name: grouped[name][0] for name in wanted if grouped.get(name)}
+    missing_names = [name for name in wanted if name not in by_name]
+    return by_name, missing_names
+
+
+def load_owner_transaction_tags(
+    db: Session,
+    *,
+    ledger: Ledger,
+) -> list[UserTagProjection]:
+    """一次载入 Owner 的标签，供一个同步批次内多笔交易复用。"""
+    return list(
+        db.scalars(
+            select(UserTagProjection).where(
+                UserTagProjection.user_id == ledger.user_id,
+            )
+        ).all()
+    )
 
 
 def _normalize_names(raw: Any) -> list[str]:

--- a/tests/test_shared_transaction_tag_validation.py
+++ b/tests/test_shared_transaction_tag_validation.py
@@ -1,0 +1,341 @@
+"""共享账本交易只能引用 Owner 标签。"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.database import Base, get_db
+from src.main import app
+from src.models import (
+    Ledger,
+    LedgerMember,
+    ReadTxProjection,
+    SyncChange,
+    UserTagProjection,
+)
+
+
+def _make_client():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(
+        bind=engine,
+        autocommit=False,
+        autoflush=False,
+    )
+
+    def override_get_db():
+        db = session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app), session_factory
+
+
+def _register(client: TestClient, email: str, device_id: str) -> dict:
+    response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "password": "Pa$$word1!",
+            "device_id": device_id,
+            "client_type": "app",
+            "device_name": f"pytest-{device_id}",
+            "platform": "test",
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def _login_web(client: TestClient, email: str) -> str:
+    response = client.post(
+        "/api/v1/auth/login",
+        json={
+            "email": email,
+            "password": "Pa$$word1!",
+            "device_id": "web-device",
+            "client_type": "web",
+            "device_name": "pytest-web",
+            "platform": "test",
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def _seed_shared_ledger(
+    session_factory,
+    *,
+    owner_id: str,
+    editor_id: str,
+    external_id: str,
+) -> str:
+    with session_factory() as db:
+        ledger = Ledger(
+            user_id=owner_id,
+            external_id=external_id,
+            name="Shared",
+        )
+        db.add(ledger)
+        db.flush()
+        db.add_all(
+            [
+                LedgerMember(
+                    ledger_id=ledger.id,
+                    user_id=owner_id,
+                    role="owner",
+                ),
+                LedgerMember(
+                    ledger_id=ledger.id,
+                    user_id=editor_id,
+                    role="editor",
+                    invited_by=owner_id,
+                ),
+                UserTagProjection(
+                    user_id=owner_id,
+                    sync_id="owner-tag",
+                    name="Owner Tag",
+                    source_change_id=1,
+                ),
+                UserTagProjection(
+                    user_id=editor_id,
+                    sync_id="editor-tag",
+                    name="Editor Tag",
+                    source_change_id=1,
+                ),
+            ]
+        )
+        db.commit()
+        return ledger.id
+
+
+def _push_transaction(
+    client: TestClient,
+    *,
+    token: str,
+    device_id: str,
+    ledger_id: str,
+    tx_id: str,
+    payload: dict,
+) -> dict:
+    response = client.post(
+        "/api/v1/sync/push",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "device_id": device_id,
+            "changes": [
+                {
+                    "ledger_id": ledger_id,
+                    "entity_type": "transaction",
+                    "entity_sync_id": tx_id,
+                    "action": "upsert",
+                    "updated_at": datetime.now(timezone.utc).isoformat(),
+                    "payload": {
+                        "syncId": tx_id,
+                        "type": "expense",
+                        "amount": 10,
+                        "happenedAt": datetime.now(timezone.utc).isoformat(),
+                        **payload,
+                    },
+                }
+            ],
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def test_mobile_shared_tx_rejects_editor_tags_and_canonicalizes_owner_tag() -> None:
+    client, session_factory = _make_client()
+    try:
+        owner = _register(client, "owner-mobile-tags@example.com", "owner-app")
+        editor = _register(client, "editor-mobile-tags@example.com", "editor-app")
+        ledger_internal_id = _seed_shared_ledger(
+            session_factory,
+            owner_id=owner["user"]["id"],
+            editor_id=editor["user"]["id"],
+            external_id="shared-mobile-tags",
+        )
+
+        unknown = _push_transaction(
+            client,
+            token=editor["access_token"],
+            device_id=editor["device_id"],
+            ledger_id="shared-mobile-tags",
+            tx_id="tx-unknown-name",
+            payload={"tags": "Editor Only"},
+        )
+        assert unknown["accepted"] == 0
+        assert unknown["rejected"] == 1
+
+        foreign_id = _push_transaction(
+            client,
+            token=editor["access_token"],
+            device_id=editor["device_id"],
+            ledger_id="shared-mobile-tags",
+            tx_id="tx-editor-id",
+            payload={"tags": "Editor Tag", "tagIds": ["editor-tag"]},
+        )
+        assert foreign_id["accepted"] == 0
+        assert foreign_id["rejected"] == 1
+
+        valid = _push_transaction(
+            client,
+            token=editor["access_token"],
+            device_id=editor["device_id"],
+            ledger_id="shared-mobile-tags",
+            tx_id="tx-owner-tag",
+            payload={"tags": "伪造名称", "tagIds": ["owner-tag"]},
+        )
+        assert valid["accepted"] == 1
+        assert valid["rejected"] == 0
+
+        with session_factory() as db:
+            invalid_changes = db.scalars(
+                select(SyncChange).where(
+                    SyncChange.entity_sync_id.in_(
+                        ["tx-unknown-name", "tx-editor-id"]
+                    )
+                )
+            ).all()
+            assert invalid_changes == []
+            tx = db.scalar(
+                select(ReadTxProjection).where(
+                    ReadTxProjection.ledger_id == ledger_internal_id,
+                    ReadTxProjection.sync_id == "tx-owner-tag",
+                )
+            )
+            assert tx is not None
+            assert tx.tags_csv == "Owner Tag"
+            assert json.loads(tx.tag_sync_ids_json or "[]") == ["owner-tag"]
+
+        # 个人账本保持老协议兼容：只有 name、没有 tagIds 的交易仍可接受。
+        personal = _push_transaction(
+            client,
+            token=owner["access_token"],
+            device_id=owner["device_id"],
+            ledger_id="personal-mobile-tags",
+            tx_id="tx-personal-legacy",
+            payload={"tags": "Legacy Personal Tag"},
+        )
+        assert personal["accepted"] == 1
+        assert personal["rejected"] == 0
+    finally:
+        client.close()
+        app.dependency_overrides.clear()
+
+
+def test_web_shared_tx_resolves_known_owner_name_and_rejects_unknown() -> None:
+    client, session_factory = _make_client()
+    try:
+        owner = _register(client, "owner-web-tags@example.com", "owner-app")
+        editor = _register(client, "editor-web-tags@example.com", "editor-app")
+        ledger_internal_id = _seed_shared_ledger(
+            session_factory,
+            owner_id=owner["user"]["id"],
+            editor_id=editor["user"]["id"],
+            external_id="shared-web-tags",
+        )
+        web_token = _login_web(client, "editor-web-tags@example.com")
+        headers = {
+            "Authorization": f"Bearer {web_token}",
+            "X-Device-ID": "web-device",
+        }
+        base_payload = {
+            "base_change_id": 0,
+            "tx_type": "expense",
+            "amount": 12,
+            "happened_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        rejected = client.post(
+            "/api/v1/write/ledgers/shared-web-tags/transactions",
+            headers=headers,
+            json={**base_payload, "tags": ["Editor Only"]},
+        )
+        assert rejected.status_code == 400, rejected.text
+        assert rejected.json()["error_code"] == "SHARED_TX_TAG_NOT_OWNER"
+
+        accepted = client.post(
+            "/api/v1/write/ledgers/shared-web-tags/transactions",
+            headers=headers,
+            json={**base_payload, "tags": ["Owner Tag"]},
+        )
+        assert accepted.status_code == 200, accepted.text
+        tx_id = accepted.json()["entity_id"]
+
+        with session_factory() as db:
+            tx = db.scalar(
+                select(ReadTxProjection).where(
+                    ReadTxProjection.ledger_id == ledger_internal_id,
+                    ReadTxProjection.sync_id == tx_id,
+                )
+            )
+            assert tx is not None
+            assert tx.tags_csv == "Owner Tag"
+            assert json.loads(tx.tag_sync_ids_json or "[]") == ["owner-tag"]
+    finally:
+        client.close()
+        app.dependency_overrides.clear()
+
+
+def test_editor_batch_cannot_create_unknown_shared_tag() -> None:
+    client, session_factory = _make_client()
+    try:
+        owner = _register(client, "owner-batch-tags@example.com", "owner-app")
+        editor = _register(client, "editor-batch-tags@example.com", "editor-app")
+        _seed_shared_ledger(
+            session_factory,
+            owner_id=owner["user"]["id"],
+            editor_id=editor["user"]["id"],
+            external_id="shared-batch-tags",
+        )
+        web_token = _login_web(client, "editor-batch-tags@example.com")
+        headers = {
+            "Authorization": f"Bearer {web_token}",
+            "X-Device-ID": "web-device",
+        }
+
+        response = client.post(
+            "/api/v1/write/ledgers/shared-batch-tags/transactions/batch",
+            headers=headers,
+            json={
+                "base_change_id": 0,
+                "auto_ai_tag": False,
+                "transactions": [
+                    {
+                        "tx_type": "expense",
+                        "amount": 8,
+                        "happened_at": datetime.now(timezone.utc).isoformat(),
+                        "tags": ["Editor Only"],
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 400, response.text
+        assert response.json()["error_code"] == "SHARED_TX_TAG_NOT_OWNER"
+
+        with session_factory() as db:
+            editor_tag = db.scalar(
+                select(UserTagProjection).where(
+                    UserTagProjection.user_id == editor["user"]["id"],
+                    UserTagProjection.name == "Editor Only",
+                )
+            )
+            assert editor_tag is None
+    finally:
+        client.close()
+        app.dependency_overrides.clear()

--- a/tests/test_shared_transaction_tag_validation.py
+++ b/tests/test_shared_transaction_tag_validation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
+from pathlib import Path
 
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, select
@@ -12,6 +13,7 @@ from sqlalchemy.pool import StaticPool
 from src.database import Base, get_db
 from src.main import app
 from src.models import (
+    AttachmentFile,
     Ledger,
     LedgerMember,
     ReadTxProjection,
@@ -130,35 +132,47 @@ def _push_transaction(
     ledger_id: str,
     tx_id: str,
     payload: dict,
+    updated_at: datetime | None = None,
+    expected_status: int = 200,
 ) -> dict:
+    change_time = updated_at or datetime.now(timezone.utc)
     response = client.post(
         "/api/v1/sync/push",
         headers={"Authorization": f"Bearer {token}"},
         json={
             "device_id": device_id,
-            "changes": [
-                {
-                    "ledger_id": ledger_id,
-                    "entity_type": "transaction",
-                    "entity_sync_id": tx_id,
-                    "action": "upsert",
-                    "updated_at": datetime.now(timezone.utc).isoformat(),
-                    "payload": {
-                        "syncId": tx_id,
-                        "type": "expense",
-                        "amount": 10,
-                        "happenedAt": datetime.now(timezone.utc).isoformat(),
-                        **payload,
-                    },
-                }
-            ],
+            "changes": [_transaction_change(ledger_id, tx_id, payload, change_time)],
         },
     )
-    assert response.status_code == 200, response.text
+    assert response.status_code == expected_status, response.text
     return response.json()
 
 
-def test_mobile_shared_tx_rejects_editor_tags_and_canonicalizes_owner_tag() -> None:
+def _transaction_change(
+    ledger_id: str,
+    tx_id: str,
+    payload: dict,
+    updated_at: datetime | None = None,
+) -> dict:
+    return {
+        "ledger_id": ledger_id,
+        "entity_type": "transaction",
+        "entity_sync_id": tx_id,
+        "action": "upsert",
+        "updated_at": (updated_at or datetime.now(timezone.utc)).isoformat(),
+        "payload": {
+            "syncId": tx_id,
+            "type": "expense",
+            "amount": 10,
+            "happenedAt": datetime.now(timezone.utc).isoformat(),
+            **payload,
+        },
+    }
+
+
+def test_mobile_shared_tx_rejects_editor_tags_and_canonicalizes_owner_tag(
+    tmp_path: Path,
+) -> None:
     client, session_factory = _make_client()
     try:
         owner = _register(client, "owner-mobile-tags@example.com", "owner-app")
@@ -170,6 +184,45 @@ def test_mobile_shared_tx_rejects_editor_tags_and_canonicalizes_owner_tag() -> N
             external_id="shared-mobile-tags",
         )
 
+        # 构造一个已有附件的交易。后面的混合批先移除附件、再遇到非法标签；
+        # 整批 400 时除了 DB 行必须 rollback，物理文件也不能提前被 unlink。
+        attachment_path = tmp_path / "mixed-rollback.bin"
+        attachment_path.write_bytes(b"keep after rollback")
+        with session_factory() as db:
+            db.add_all(
+                [
+                    AttachmentFile(
+                        id="mixed-rollback-file",
+                        ledger_id=ledger_internal_id,
+                        user_id=owner["user"]["id"],
+                        sha256="mixed-rollback-sha",
+                        size_bytes=19,
+                        mime_type="application/octet-stream",
+                        file_name="mixed-rollback.bin",
+                        storage_path=str(attachment_path),
+                    ),
+                    ReadTxProjection(
+                        ledger_id=ledger_internal_id,
+                        sync_id="tx-mixed-attachment",
+                        user_id=owner["user"]["id"],
+                        tx_type="expense",
+                        amount=10,
+                        happened_at=datetime.now(timezone.utc),
+                        attachments_json=json.dumps(
+                            [
+                                {
+                                    "fileName": "mixed-rollback.bin",
+                                    "cloudFileId": "mixed-rollback-file",
+                                }
+                            ]
+                        ),
+                        tx_index=0,
+                        source_change_id=1,
+                    ),
+                ]
+            )
+            db.commit()
+
         unknown = _push_transaction(
             client,
             token=editor["access_token"],
@@ -177,9 +230,9 @@ def test_mobile_shared_tx_rejects_editor_tags_and_canonicalizes_owner_tag() -> N
             ledger_id="shared-mobile-tags",
             tx_id="tx-unknown-name",
             payload={"tags": "Editor Only"},
+            expected_status=400,
         )
-        assert unknown["accepted"] == 0
-        assert unknown["rejected"] == 1
+        assert unknown["error_code"] == "SHARED_TX_TAG_NOT_OWNER"
 
         foreign_id = _push_transaction(
             client,
@@ -188,10 +241,39 @@ def test_mobile_shared_tx_rejects_editor_tags_and_canonicalizes_owner_tag() -> N
             ledger_id="shared-mobile-tags",
             tx_id="tx-editor-id",
             payload={"tags": "Editor Tag", "tagIds": ["editor-tag"]},
+            expected_status=400,
         )
-        assert foreign_id["accepted"] == 0
-        assert foreign_id["rejected"] == 1
+        assert foreign_id["error_code"] == "SHARED_TX_TAG_NOT_OWNER"
 
+        # 一批中前一条已 flush、后一条标签非法时必须整体 400 + rollback，
+        # 防止客户端保留整批 local changes、服务端却只落一半。
+        mixed = client.post(
+            "/api/v1/sync/push",
+            headers={"Authorization": f"Bearer {editor['access_token']}"},
+            json={
+                "device_id": editor["device_id"],
+                "changes": [
+                    _transaction_change(
+                        "shared-mobile-tags",
+                        "tx-mixed-attachment",
+                        {
+                            "tags": "Owner Tag",
+                            "tagIds": ["owner-tag"],
+                            "attachments": [],
+                        },
+                    ),
+                    _transaction_change(
+                        "shared-mobile-tags",
+                        "tx-mixed-invalid",
+                        {"tags": "Editor Only"},
+                    ),
+                ],
+            },
+        )
+        assert mixed.status_code == 400, mixed.text
+        assert mixed.json()["error_code"] == "SHARED_TX_TAG_NOT_OWNER"
+
+        replay_time = datetime.now(timezone.utc)
         valid = _push_transaction(
             client,
             token=editor["access_token"],
@@ -199,6 +281,7 @@ def test_mobile_shared_tx_rejects_editor_tags_and_canonicalizes_owner_tag() -> N
             ledger_id="shared-mobile-tags",
             tx_id="tx-owner-tag",
             payload={"tags": "伪造名称", "tagIds": ["owner-tag"]},
+            updated_at=replay_time,
         )
         assert valid["accepted"] == 1
         assert valid["rejected"] == 0
@@ -207,11 +290,31 @@ def test_mobile_shared_tx_rejects_editor_tags_and_canonicalizes_owner_tag() -> N
             invalid_changes = db.scalars(
                 select(SyncChange).where(
                     SyncChange.entity_sync_id.in_(
-                        ["tx-unknown-name", "tx-editor-id"]
+                        [
+                            "tx-unknown-name",
+                            "tx-editor-id",
+                            "tx-mixed-attachment",
+                            "tx-mixed-invalid",
+                        ]
                     )
                 )
             ).all()
             assert invalid_changes == []
+            rolled_back_tx = db.scalar(
+                select(ReadTxProjection).where(
+                    ReadTxProjection.ledger_id == ledger_internal_id,
+                    ReadTxProjection.sync_id == "tx-mixed-attachment",
+                )
+            )
+            assert rolled_back_tx is not None
+            assert json.loads(rolled_back_tx.attachments_json or "[]") == [
+                {
+                    "fileName": "mixed-rollback.bin",
+                    "cloudFileId": "mixed-rollback-file",
+                }
+            ]
+            assert db.get(AttachmentFile, "mixed-rollback-file") is not None
+            assert attachment_path.exists()
             tx = db.scalar(
                 select(ReadTxProjection).where(
                     ReadTxProjection.ledger_id == ledger_internal_id,
@@ -221,6 +324,30 @@ def test_mobile_shared_tx_rejects_editor_tags_and_canonicalizes_owner_tag() -> N
             assert tx is not None
             assert tx.tags_csv == "Owner Tag"
             assert json.loads(tx.tag_sync_ids_json or "[]") == ["owner-tag"]
+
+            # 标签后来被删除时，相同 device/timestamp 的重放仍应先命中 LWW
+            # equality，不能重新校验已经接受过的旧 payload。
+            owner_tag = db.scalar(
+                select(UserTagProjection).where(
+                    UserTagProjection.user_id == owner["user"]["id"],
+                    UserTagProjection.sync_id == "owner-tag",
+                )
+            )
+            assert owner_tag is not None
+            db.delete(owner_tag)
+            db.commit()
+
+        replay = _push_transaction(
+            client,
+            token=editor["access_token"],
+            device_id=editor["device_id"],
+            ledger_id="shared-mobile-tags",
+            tx_id="tx-owner-tag",
+            payload={"tags": "Owner Tag", "tagIds": ["owner-tag"]},
+            updated_at=replay_time,
+        )
+        assert replay["accepted"] == 1
+        assert replay["rejected"] == 0
 
         # 个人账本保持老协议兼容：只有 name、没有 tagIds 的交易仍可接受。
         personal = _push_transaction(
@@ -287,12 +414,32 @@ def test_web_shared_tx_resolves_known_owner_name_and_rejects_unknown() -> None:
             assert tx is not None
             assert tx.tags_csv == "Owner Tag"
             assert json.loads(tx.tag_sync_ids_json or "[]") == ["owner-tag"]
+
+            db.add(
+                UserTagProjection(
+                    user_id=owner["user"]["id"],
+                    sync_id="owner-tag-duplicate",
+                    name="Owner Tag",
+                    source_change_id=2,
+                )
+            )
+            db.commit()
+
+        ambiguous = client.post(
+            "/api/v1/write/ledgers/shared-web-tags/transactions",
+            headers=headers,
+            json={**base_payload, "tags": ["Owner Tag"]},
+        )
+        assert ambiguous.status_code == 400, ambiguous.text
+        assert ambiguous.json()["error_code"] == "SHARED_TX_TAG_AMBIGUOUS"
     finally:
         client.close()
         app.dependency_overrides.clear()
 
 
 def test_editor_batch_cannot_create_unknown_shared_tag() -> None:
+    from src.services.ai.image_cache import clear_cache, peek_image, store_image
+
     client, session_factory = _make_client()
     try:
         owner = _register(client, "owner-batch-tags@example.com", "owner-app")
@@ -309,12 +456,18 @@ def test_editor_batch_cannot_create_unknown_shared_tag() -> None:
             "X-Device-ID": "web-device",
         }
 
+        image_id = store_image(
+            image_bytes=b"not-consumed-on-tag-error",
+            mime_type="image/png",
+            user_id=editor["user"]["id"],
+        )
         response = client.post(
             "/api/v1/write/ledgers/shared-batch-tags/transactions/batch",
             headers=headers,
             json={
                 "base_change_id": 0,
                 "auto_ai_tag": False,
+                "attach_image_id": image_id,
                 "transactions": [
                     {
                         "tx_type": "expense",
@@ -327,6 +480,7 @@ def test_editor_batch_cannot_create_unknown_shared_tag() -> None:
         )
         assert response.status_code == 400, response.text
         assert response.json()["error_code"] == "SHARED_TX_TAG_NOT_OWNER"
+        assert peek_image(image_id=image_id, user_id=editor["user"]["id"]) is not None
 
         with session_factory() as db:
             editor_tag = db.scalar(
@@ -336,6 +490,92 @@ def test_editor_batch_cannot_create_unknown_shared_tag() -> None:
                 )
             )
             assert editor_tag is None
+
+            db.add(
+                UserTagProjection(
+                    user_id=owner["user"]["id"],
+                    sync_id="owner-tag-duplicate",
+                    name="Owner Tag",
+                    source_change_id=2,
+                )
+            )
+            db.commit()
+
+        ambiguous = client.post(
+            "/api/v1/write/ledgers/shared-batch-tags/transactions/batch",
+            headers=headers,
+            json={
+                "base_change_id": 0,
+                "auto_ai_tag": False,
+                "transactions": [
+                    {
+                        "tx_type": "expense",
+                        "amount": 8,
+                        "happened_at": datetime.now(timezone.utc).isoformat(),
+                        "tags": ["Owner Tag"],
+                    }
+                ],
+            },
+        )
+        assert ambiguous.status_code == 400, ambiguous.text
+        assert ambiguous.json()["error_code"] == "SHARED_TX_TAG_AMBIGUOUS"
+    finally:
+        clear_cache()
+        client.close()
+        app.dependency_overrides.clear()
+
+
+def test_editor_import_rejects_unknown_shared_tag() -> None:
+    client, session_factory = _make_client()
+    try:
+        owner = _register(client, "owner-import-tags@example.com", "owner-app")
+        editor = _register(client, "editor-import-tags@example.com", "editor-app")
+        _seed_shared_ledger(
+            session_factory,
+            owner_id=owner["user"]["id"],
+            editor_id=editor["user"]["id"],
+            external_id="shared-import-tags",
+        )
+        web_token = _login_web(client, "editor-import-tags@example.com")
+        headers = {"Authorization": f"Bearer {web_token}"}
+        csv_text = (
+            "Type,Category,Subcategory,Amount,Account,From Account,To Account,"
+            "Note,Time,Tags,Attachments\n"
+            "Expense,,,8,,,,imported,2026-08-09 12:00:00,Editor Only,\n"
+        )
+        upload = client.post(
+            "/api/v1/import/upload",
+            headers=headers,
+            files={"file": ("shared.csv", csv_text.encode(), "text/csv")},
+            data={"target_ledger_id": "shared-import-tags"},
+        )
+        assert upload.status_code == 200, upload.text
+
+        execute = client.post(
+            f"/api/v1/import/{upload.json()['import_token']}/execute",
+            headers=headers,
+        )
+        assert execute.status_code == 200, execute.text
+        assert '"code": "SHARED_TX_TAG_NOT_OWNER"' in execute.text
+
+        with session_factory() as db:
+            txs = db.scalars(
+                select(ReadTxProjection).where(
+                    ReadTxProjection.ledger_id == db.scalar(
+                        select(Ledger.id).where(
+                            Ledger.external_id == "shared-import-tags"
+                        )
+                    )
+                )
+            ).all()
+            assert txs == []
+            leaked_tag = db.scalar(
+                select(UserTagProjection).where(
+                    UserTagProjection.user_id == editor["user"]["id"],
+                    UserTagProjection.name == "Editor Only",
+                )
+            )
+            assert leaked_tag is None
     finally:
         client.close()
         app.dependency_overrides.clear()


### PR DESCRIPTION
## 背景

关联 TNT-Likely/BeeCount#435，配套 App 修复：TNT-Likely/BeeCount#436。

共享账本的标签属于 Owner 的 user-global 资源，但服务端此前会信任交易 payload 中的 `tags` / `tagIds`。Editor 因此可以提交自己的标签 ID 或只有名称的未知标签，Owner 客户端拉取后又会按名称 fallback 创建新标签，最终产生同名不同 `syncId` 的重复数据。

## 修改内容

- 新增统一的共享交易标签校验与规范化逻辑：
  - `tagIds` / `tag_ids` 必须属于账本 Owner；
  - 只有名称时，只允许解析已有 Owner 标签；
  - ID 有效时按 Owner 标签回填规范名称；
  - 同名但不同 ID 的 Owner 标签视为歧义并明确拒绝；
  - 显式清空时同时清理名称和 ID。
- Mobile `/sync/push`：
  - 非法标签返回 HTTP 400，整批回滚，避免 App 收到 2xx 后把未落库 change 静默出队；
  - LWW conflict / replay 在标签校验前处理，幂等重放不受标签后续删除或重命名影响；
  - 账本共享状态和 Owner 标签按批次缓存，每个账本只获取一次 advisory lock；
  - 附件物理删除延迟到数据库 commit 成功后，后续 change 失败时不会留下“DB 回滚但文件已丢失”的状态。
- Web 单笔及 Web/AI 批量交易：
  - 在账本锁内执行相同校验；
  - Editor 不能隐式创建共享账本标签；
  - 标签错误发生在图片缓存消费和附件文件创建之前。
- CSV 导入：
  - 共享账本按 Owner 标签解析，并同时写入名称和 tag ID；
  - Editor 的未知标签及同名歧义都会拒绝。
- 个人账本保留原有 name-only 兼容行为。

## Agentic code review

使用三个独立 review agent 分别审查同步/LWW、Web/导入/批量写入、测试覆盖；首轮发现的问题均已修复，二次复审未发现 P0–P2。

重点补修：

- Mobile 2xx 静默丢失；
- LWW/replay 校验顺序；
- 混合批次附件不可逆删除；
- Owner tag row lock 与 ledger lock 的锁序死锁；
- 同名 Owner 标签随机绑定；
- CSV 导入绕过；
- 批量图片缓存提前消费；
- 重复标签查询和重复 advisory lock。

## 测试

为避免本地 OOM，所有测试都在 Docker 中限制为 1 CPU、768MB 内存（Ruff 为 512MB）：

- 新增共享交易标签回归：4 passed；
- 标签、附件 GC、共享账本、同步并发、导入、Web/AI 批量写入相关回归：76 passed；
- 完整 pytest：passed（排除会被 pytest 误收集的非测试路由 `src/routers/ai/test_provider.py`）；
- Ruff undefined-name/syntax 检查及新增 service/test 完整规则：passed。

测试期间未发生 OOM。
