### PR TITLE
feat(ai): 智能记账支持多币种(#437)

### DIFF
--- a/frontend/apps/web/src/components/cmdk-ai/TxDraftList.tsx
+++ b/frontend/apps/web/src/components/cmdk-ai/TxDraftList.tsx
@@ -23,9 +23,15 @@ import {
   useT,
   useToast,
 } from '@beecount/ui'
-import { CategoryPickerDialog } from '@beecount/web-features'
+import {
+  CategoryPickerDialog,
+  CurrencySelectorTrigger,
+  loadRatesToBase,
+  resolveCurrencyFields,
+} from '@beecount/web-features'
 
 import { useAuth } from '../../context/AuthContext'
+import { useLedgers } from '../../context/LedgersContext'
 
 export type TxDraftListProps = {
   drafts: TxDraft[]
@@ -58,12 +64,17 @@ export function TxDraftList({
   const t = useT()
   const { token } = useAuth()
   const toast = useToast()
+  const { currentLedger } = useLedgers()
+
+  // v30 多币种:账本本位币 = 草稿币种的默认值与折算目标(.docs/multi-currency-ai)
+  const baseCurrency = (currentLedger?.currency || 'CNY').trim().toUpperCase()
 
   const [categories, setCategories] = useState<WorkspaceCategory[]>([])
   const [accounts, setAccounts] = useState<WorkspaceAccount[]>([])
   const [editable, setEditable] = useState<Editable[]>([])
   const [autoAiTag, setAutoAiTag] = useState(true)
   const [saving, setSaving] = useState(false)
+  const [currencyRates, setCurrencyRates] = useState<Record<string, number>>({})
 
   // 加载 ledger candidates(必须先加载,然后才能初始化 editable 把 LLM name 映射到 id)
   useEffect(() => {
@@ -82,8 +93,29 @@ export function TxDraftList({
 
   // 候选数据 ready 后初始化 editable;drafts 变化(重新解析)也重置
   useEffect(() => {
-    setEditable(initialDrafts.map((d) => toEditable(d, categories, accounts)))
-  }, [initialDrafts, categories, accounts])
+    setEditable(initialDrafts.map((d) => toEditable(d, categories, accounts, baseCurrency)))
+  }, [initialDrafts, categories, accounts, baseCurrency])
+
+  // 汇率只在真的沾多币种时才拉:账本里有外币账户,或某笔草稿选了外币。
+  // 纯单币种用户不会因为这个功能多一次网络请求(loadRatesToBase 自带 5min 缓存)。
+  const needRates = useMemo(
+    () =>
+      accounts.some((a) => (a.currency || baseCurrency).toUpperCase() !== baseCurrency) ||
+      editable.some((d) => d.currency && d.currency !== baseCurrency),
+    [accounts, editable, baseCurrency],
+  )
+  useEffect(() => {
+    if (!needRates) return
+    let alive = true
+    loadRatesToBase(token, baseCurrency)
+      .then((r) => {
+        if (alive) setCurrencyRates(r)
+      })
+      .catch(() => {})
+    return () => {
+      alive = false
+    }
+  }, [needRates, token, baseCurrency])
 
   const selected = useMemo(() => editable.filter((d) => d.selected), [editable])
   const allChecked = editable.length > 0 && editable.every((d) => d.selected)
@@ -117,11 +149,37 @@ export function TxDraftList({
     }
     setSaving(true)
     try {
+      // v30 多币种:逐笔折算到账本本位币。transfer 不带币种字段(跨币种转账
+      // 本就有守卫);拉不到汇率 → 阻断保存,绝不静默按 1:1 入账(App L8 同源)。
+      // Web 是有人值守的确认式交互,所以这里阻断而不像 App 无人值守通道那样降级。
+      let currencyByLocalId: Record<string, { currency_code: string; native_amount: number }> = {}
+      try {
+        const resolved = await Promise.all(
+          selected.map(async (d) => {
+            if (d.type === 'transfer') return null
+            const fields = await resolveCurrencyFields({
+              token,
+              ledgerBase: baseCurrency,
+              currency: d.currency,
+              amount: Number(d.amountText) || 0,
+            })
+            return fields ? ([d.localId, fields] as const) : null
+          }),
+        )
+        currencyByLocalId = Object.fromEntries(resolved.filter(Boolean) as [string, { currency_code: string; native_amount: number }][])
+      } catch {
+        // 复用单笔记账的同一句文案(三语已有),不新造 key
+        toast.error(t('transactions.error.rateMissing'), t('cmdk.parseTx.saveFailed'))
+        setSaving(false)
+        return
+      }
+
       const items: BatchTxItem[] = selected.map((d) => ({
         tx_type: d.type,
         amount: Number(d.amountText) || 0,
         happened_at: d.happenedAtIso,
         note: d.note || null,
+        ...(currencyByLocalId[d.localId] || {}),
         // 关键:同时传 name + id(server projection 用 id 关联,name 用作显示)
         category_name: d.categoryName || null,
         category_id: d.categoryId || null,
@@ -173,6 +231,8 @@ export function TxDraftList({
             draft={d}
             categories={categories}
             accounts={accounts}
+            baseCurrency={baseCurrency}
+            currencyRates={currencyRates}
             onChange={(patch) => updateOne(idx, patch)}
             onRemove={() => removeOne(idx)}
             t={t}
@@ -226,6 +286,8 @@ function TxCard({
   draft,
   categories,
   accounts,
+  baseCurrency,
+  currencyRates,
   onChange,
   onRemove,
   t,
@@ -233,6 +295,8 @@ function TxCard({
   draft: Editable
   categories: WorkspaceCategory[]
   accounts: WorkspaceAccount[]
+  baseCurrency: string
+  currencyRates: Record<string, number>
   onChange: (patch: Partial<Editable>) => void
   onRemove: () => void
   t: T
@@ -242,7 +306,17 @@ function TxCard({
   const missingCategory = !isTransfer && !draft.categoryId
   const [catPickerOpen, setCatPickerOpen] = useState(false)
 
-  const accountNames = useMemo(() => accounts.map((a) => a.name).filter(Boolean), [accounts])
+  // v30 多币种:账户候选跟着**这笔的币种**走(与 TransactionsPanel 的
+  // 「选非本位币 → 账户下拉按币种过滤」同构)。单币种账本下该过滤是恒真的。
+  const txCurrency = draft.currency || baseCurrency
+  const accountNames = useMemo(
+    () =>
+      accounts
+        .filter((a) => (a.currency || baseCurrency).toUpperCase() === txCurrency.toUpperCase())
+        .map((a) => a.name)
+        .filter(Boolean),
+    [accounts, txCurrency, baseCurrency],
+  )
 
   // type 变化时同步 categoryKind 候选
   const pickerKind: 'expense' | 'income' = draft.type === 'income' ? 'income' : 'expense'
@@ -307,6 +381,28 @@ function TxCard({
           <Trash2 className="h-3.5 w-3.5" />
         </button>
       </div>
+
+      {/* v30 多币种:币种行,与 TransactionsPanel 的单笔表单同构(那边也是非
+          transfer 就常驻)。常驻而非「只在外币时显示」是因为 AI 有可能漏识别
+          币种 —— 用户必须能在保存前改回来,否则只能存完再逐笔编辑(#437)。 */}
+      {!isTransfer ? (
+        <div className="mt-2">
+          <CurrencySelectorTrigger
+            value={draft.currency || baseCurrency}
+            onChange={(code) => {
+              const next = code.trim().toUpperCase()
+              onChange({
+                currency: next === baseCurrency ? '' : next,
+                // 币种变了,原账户多半不再同币种 → 清空,让用户在新候选里重选
+                accountName: '',
+                accountId: '',
+              })
+            }}
+            ratesToBase={currencyRates}
+            rateBase={baseCurrency}
+          />
+        </div>
+      ) : null}
 
       {/* 类目 + 账户(transfer 换 from/to) */}
       <div className="mt-2 grid grid-cols-2 gap-2">
@@ -512,6 +608,8 @@ type Editable = {
   amountText: string
   happenedAtIso: string
   note: string
+  /** 原币种 ISO;'' = 账本本位币(与 TxForm.currency 同约定) */
+  currency: string
   tags: string[]
   confidence: TxDraft['confidence']
   categoryId: string
@@ -528,6 +626,7 @@ function toEditable(
   d: TxDraft,
   categories: WorkspaceCategory[],
   accounts: WorkspaceAccount[],
+  baseCurrency: string,
 ): Editable {
   // 「有子分类的父类」不能被作为交易分类(产品规则跟 mobile 一致)。如果 LLM 返
   // 了这种父类名字,我们 lookup 时拒绝命中,categoryId 留空 → 用户在 Picker
@@ -554,8 +653,21 @@ function toEditable(
     return accounts.find((a) => a.name === name) || null
   }
 
+  // v30 多币种:LLM 给的币种(server 已校验成 ISO 或 "")。等于本位币就归一成
+  // '' —— 与 TxForm.currency 同约定,提交时才展开成显式 currency_code。
+  const draftCurrency = (d.currency || '').trim().toUpperCase()
+  const currency = draftCurrency === baseCurrency ? '' : draftCurrency
+  const txCurrency = currency || baseCurrency
+
   const cat = matchCategory(d.category_name, d.type)
-  const acct = matchAccount(d.account_name)
+  // 账户必须与这笔的币种一致 —— 卡片里的账户下拉就是按币种过滤的,匹配到一个
+  // 不在候选里的账户会让 Select 显示一个选不中的值。币种不符视为未匹配,
+  // 用户在过滤后的候选里重选(与 mobile BillCreationService 的匹配池同口径)。
+  const acctByName = matchAccount(d.account_name)
+  const acct =
+    acctByName && (acctByName.currency || baseCurrency).toUpperCase() === txCurrency
+      ? acctByName
+      : null
   const fromAcct = d.from_account_name ? matchAccount(d.from_account_name) : null
   const toAcct = d.to_account_name ? matchAccount(d.to_account_name) : null
 
@@ -566,6 +678,7 @@ function toEditable(
     amountText: String(d.amount),
     happenedAtIso: d.happened_at || new Date().toISOString(),
     note: d.note || '',
+    currency,
     tags: d.tags || [],
     confidence: d.confidence,
     categoryId: cat?.id || '',

--- a/frontend/packages/api-client/src/ai.ts
+++ b/frontend/packages/api-client/src/ai.ts
@@ -108,6 +108,8 @@ export type TxDraft = {
   from_account_name: string | null
   to_account_name: string | null
   note: string
+  /** 原币种 ISO 4217(server 已校验);'' = 跟账本主币种。老 server 不返此字段。 */
+  currency?: string
   tags: string[]
   confidence: 'high' | 'medium' | 'low'
 }

--- a/src/mcp/server.py
+++ b/src/mcp/server.py
@@ -350,6 +350,7 @@ async def create_transaction(
     note: str | None = None,
     tags: list[str] | None = None,
     ledger_id: str | None = None,
+    currency: str | None = None,
 ) -> dict[str, Any]:
     """Create a new transaction.
 
@@ -362,10 +363,15 @@ async def create_transaction(
         note: Optional memo.
         tags: Optional list of tag names.
         ledger_id: Optional; uses active ledger if omitted.
+        currency: ISO 4217 code (e.g. 'USD', 'JPY') when the amount is in a
+            foreign currency. Omit to follow the account's currency, or the
+            ledger's base currency when no account is given. The server converts
+            to the ledger base at current rates and stores both amounts.
     """
     kw = dict(
         amount=amount, tx_type=tx_type, category=category, account=account,
         happened_at=happened_at, note=note, tags=tags, ledger_id=ledger_id,
+        currency=currency,
     )
     return await _logged_call(
         ctx, name="create_transaction", scope=SCOPE_MCP_WRITE, kwargs=kw,
@@ -388,7 +394,8 @@ async def create_transactions(
     Args:
         transactions: list of objects, each like create_transaction's args —
             {amount (>0), tx_type (expense|income|transfer, default expense),
-             category, account, happened_at (ISO, default now), note, tags}.
+             category, account, happened_at (ISO, default now), note, tags,
+             currency (ISO 4217, only for foreign-currency amounts)}.
             category/account must be existing names (server rejects unknown ones).
         ledger_id: Optional. If omitted and you have multiple ledgers, the tool
             refuses to guess and returns the candidate list — re-call with an id.

--- a/src/mcp/tools/write_tools.py
+++ b/src/mcp/tools/write_tools.py
@@ -620,6 +620,9 @@ async def parse_and_create_from_text(
     account = draft.get("account_name")
     happened_at = draft.get("happened_at")
     note = draft.get("note") or text
+    # 多币种(.docs/multi-currency-ai A9):draft 的 currency 已被 server 端
+    # _norm_currency 校验成 ISO 码或 "";空串要传 None 才会走「随账户/本位币」。
+    currency = (draft.get("currency") or "").strip().upper() or None
 
     created = await create_transaction(
         user,
@@ -630,6 +633,7 @@ async def parse_and_create_from_text(
         happened_at=happened_at,
         note=note,
         ledger_id=ledger_id,
+        currency=currency,
     )
     return {"status": "created", "parsed": draft, "transaction": created}
 

--- a/src/routers/ai/parse_tx_image.py
+++ b/src/routers/ai/parse_tx_image.py
@@ -260,13 +260,20 @@ _ISO_CURRENCY_RE = re.compile(r"^[A-Z]{3}$")
 def _norm_currency(raw: object) -> str:
     """LLM 给的币种 → ISO 4217 大写码;不合法返 ""(= 跟账本主币种)。
 
-    **server 端不做别名映射**(「美元」→USD 之类):server 既没有 App 的 151
-    币种表,也没有账本上下文做 `$`/`¥` 消歧,统一让 prompt 直出 ISO 更可控。
+    **server 端基本不做别名映射**(「美元」→USD 之类):server 既没有 App 的 151
+    币种表,也没有账本上下文做 `¥` 消歧,统一让 prompt 直出 ISO 更可控。
     App 侧面对本地/口语输入才做宽松解析(.docs/multi-currency-ai §3.2)。
+
+    唯一例外是裸 `$` → USD:实测 LLM 明明识别出「45 美元」却常把字段回成
+    `"$"`,而这条映射既不需要币种表也不需要上下文(要区分 AUD/CAD/SGD/HKD 时
+    书写惯例都是 `A$`/`C$`/`S$`/`HK$`)。`¥` 仍**不映射** —— CNY 与 JPY 都写裸
+    `¥`,猜错是 ~20 倍金额差,宁可退回账本主币种。
     """
     if not isinstance(raw, str):
         return ""
     code = raw.strip().upper()
+    if code == "$":
+        return "USD"
     return code if _ISO_CURRENCY_RE.match(code) else ""
 
 

--- a/src/routers/ai/parse_tx_image.py
+++ b/src/routers/ai/parse_tx_image.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import base64
 import logging
+import re
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
@@ -102,10 +103,10 @@ async def parse_tx_image(
 
     # 3. 取 ledger 上下文(categories + accounts 给 LLM 选)
     # 「父类有子分类」的父类不喂给 LLM(产品规则:tx 不能直接落到这种父类)
-    cats, accts = _load_ledger_context(db, ledger_id, current_user.id)
+    cats, accts, ledger_currency = _load_ledger_context(db, ledger_id, current_user.id)
     logger.debug(
-        "ai.parse_tx_image ledger_context cats=%d accts=%d sample_cats=%s",
-        len(cats), len(accts), cats[:10],
+        "ai.parse_tx_image ledger_context cats=%d accts=%d base=%s sample_cats=%s",
+        len(cats), len(accts), ledger_currency, cats[:10],
     )
 
     # 4. 拼 prompt + 调 vision LLM
@@ -114,6 +115,7 @@ async def parse_tx_image(
     messages = build_parse_tx_image_messages(
         categories=cats,
         accounts=accts,
+        ledger_currency=ledger_currency,
         now=datetime.now(timezone.utc),
         locale=locale,
         image_data_url=image_data_url,
@@ -176,11 +178,17 @@ async def parse_tx_image(
 
 def _load_ledger_context(
     db: Session, ledger_id: str | None, user_id: str,
-) -> tuple[list[str], list[str]]:
-    """取当前账本的 category / account 名字列表(给 LLM hint)。
+) -> tuple[list[str], list[tuple[str, str | None]], str]:
+    """取当前账本的 category / account / 本位币(给 LLM hint)。
 
-    没传 ledger_id → 跨账本聚合所有用户可见的(让 LLM 至少有现成名字可选)。
+    没传 ledger_id → 跨账本聚合所有用户可见的(让 LLM 至少有现成名字可选);
+    此时本位币取「用户只有一个账本就用它,否则 CNY」—— 草稿的落库账本要等
+    用户在前端选,这里只能给 best-effort 上下文。
+
+    账户返回 `(名称, 币种)`:多币种记账要让 LLM 能选中外币账户(.docs/
+    multi-currency-ai A3)。
     """
+    fallback_currency = "CNY"
     if ledger_id:
         ledger = db.scalar(
             select(Ledger).where(
@@ -188,15 +196,20 @@ def _load_ledger_context(
             )
         )
         if ledger is None:
-            return [], []
+            return [], [], fallback_currency
         ledger_int_ids = [ledger.id]
+        ledger_currency = (ledger.currency or fallback_currency).strip().upper()
     else:
-        ledger_int_ids = [
-            l.id for l in db.scalars(select(Ledger).where(Ledger.user_id == user_id)).all()
-        ]
+        all_ledgers = db.scalars(select(Ledger).where(Ledger.user_id == user_id)).all()
+        ledger_int_ids = [l.id for l in all_ledgers]
+        ledger_currency = (
+            (all_ledgers[0].currency or fallback_currency).strip().upper()
+            if len(all_ledgers) == 1
+            else fallback_currency
+        )
 
     if not ledger_int_ids:
-        return [], []
+        return [], [], ledger_currency
 
     # category 是 user-global,按 user_id 拉(跨 ledger 统一)。
     cat_rows = db.scalars(
@@ -223,15 +236,38 @@ def _load_ledger_context(
             selectable_cats.append(c.name)
         # else: 父分类有子 → 跳过,LLM 看不到它,只看到具体的子分类
 
-    accts = [
-        a.name for a in db.scalars(
-            select(UserAccountProjection).where(
-                UserAccountProjection.user_id == user_id
-            )
-        ).all()
-        if a.name
-    ]
-    return sorted(set(selectable_cats)), sorted(set(accts))
+    # 账户隐藏(#240):隐藏账户不再作为新交易的记账目标 —— 不喂给 LLM 作候选,
+    # 与 mobile 的 AiExtractionContext / 手动选择器口径一致。
+    acct_rows = db.scalars(
+        select(UserAccountProjection).where(
+            UserAccountProjection.user_id == user_id
+        )
+    ).all()
+    accts = sorted(
+        {
+            (a.name, (a.currency or "").strip().upper() or None)
+            for a in acct_rows
+            if a.name and not a.hidden
+        },
+        key=lambda pair: pair[0],
+    )
+    return sorted(set(selectable_cats)), accts, ledger_currency
+
+
+_ISO_CURRENCY_RE = re.compile(r"^[A-Z]{3}$")
+
+
+def _norm_currency(raw: object) -> str:
+    """LLM 给的币种 → ISO 4217 大写码;不合法返 ""(= 跟账本主币种)。
+
+    **server 端不做别名映射**(「美元」→USD 之类):server 既没有 App 的 151
+    币种表,也没有账本上下文做 `$`/`¥` 消歧,统一让 prompt 直出 ISO 更可控。
+    App 侧面对本地/口语输入才做宽松解析(.docs/multi-currency-ai §3.2)。
+    """
+    if not isinstance(raw, str):
+        return ""
+    code = raw.strip().upper()
+    return code if _ISO_CURRENCY_RE.match(code) else ""
 
 
 def _normalize_drafts(result: object) -> list[dict]:
@@ -264,6 +300,9 @@ def _normalize_drafts(result: object) -> list[dict]:
         out.append({
             "type": tx_type,
             "amount": float(abs(amt)),  # 强制正数
+            # 交易级多币种(.docs/multi-currency-ai A4):"" = 跟账本主币种。
+            # 非法值降级成 "" 而不是丢弃整笔 —— AI 幻觉出的假币种不该让记账失败。
+            "currency": _norm_currency(d.get("currency")),
             "happened_at": d.get("happened_at") or "",
             "category_name": (d.get("category_name") or "").strip(),
             "account_name": (d.get("account_name") or "").strip(),

--- a/src/routers/ai/parse_tx_text.py
+++ b/src/routers/ai/parse_tx_text.py
@@ -64,10 +64,10 @@ async def parse_tx_text(
             detail={"error_code": "AI_NO_CHAT_PROVIDER", "message": str(exc)},
         )
 
-    cats, accts = _load_ledger_context(db, req.ledger_id, current_user.id)
+    cats, accts, ledger_currency = _load_ledger_context(db, req.ledger_id, current_user.id)
     logger.debug(
-        "ai.parse_tx_text ledger_context cats=%d accts=%d sample_cats=%s",
-        len(cats), len(accts), cats[:10],
+        "ai.parse_tx_text ledger_context cats=%d accts=%d base=%s sample_cats=%s",
+        len(cats), len(accts), ledger_currency, cats[:10],
     )
 
     custom = get_user_custom_prompt(profile, key="parseTxTextPrompt")
@@ -75,6 +75,7 @@ async def parse_tx_text(
         text=req.text,
         categories=cats,
         accounts=accts,
+        ledger_currency=ledger_currency,
         now=datetime.now(timezone.utc),
         locale=req.locale,
         custom_prompt_template=custom,

--- a/src/services/ai/prompts.py
+++ b/src/services/ai/prompts.py
@@ -102,8 +102,12 @@ _TX_DRAFTS_SCHEMA_ZH = """\
   - `account_name`: 从「可用账户」选,选不到用 "";仅 expense/income 有意义
   - `from_account_name` / `to_account_name`: 仅 transfer 用
   - `note`: ≤15 字商家名 / 商品名 / 简短描述
-  - `currency`: 币种 ISO 4217 代码(如 USD / JPY / EUR)。**与账本主币种相同时留 ""**;
-    只有原文/图片明确是外币(如「100 美元」「1200 円」「$45」)才填
+  - `currency`: 币种,必须是 3 位大写 ISO 4217 代码,**不要填货币符号,也不要填中文名**
+    - 常见对应:美元/美金/$ → USD,日元/日圆/円 → JPY,欧元/欧/€ → EUR,
+      英镑/£ → GBP,港币/港元 → HKD,新台币 → TWD,韩元 → KRW,泰铢 → THB
+    - 与账本主币种相同时留 ""(主币种是 CNY 时,「花了 50 元」留 "")
+    - 原文/图片出现任何外币说法(中文名、符号、代码都算)就必须填,别漏
+    - 例:「花了 45 美元」→ "USD";「星巴克 $6.5」→ "USD";「1200 日元」→ "JPY"
   - `tags`: array,可空
   - `confidence`: "high" | "medium" | "low"
     - high: 金额 + 类型 + 时间 都明确从原始内容抠出来
@@ -127,9 +131,14 @@ Each draft has fields:
   - `account_name`: pick from available accounts; "" if no match (for expense/income)
   - `from_account_name` / `to_account_name`: only for transfer
   - `note`: ≤15 chars merchant/item/short description
-  - `currency`: ISO 4217 code (e.g. USD / JPY / EUR). **Leave "" when it equals the
-    ledger's base currency**; only fill it when the source clearly states a foreign
-    currency (e.g. "100 dollars", "1200 yen", "$45")
+  - `currency`: MUST be a 3-letter uppercase ISO 4217 code — **never a currency
+    symbol, never a currency name**
+    - Mapping: dollar/dollars/$ → USD, yen/円 → JPY, euro/€ → EUR, pound/£ → GBP,
+      HK dollar → HKD, NT dollar → TWD, won → KRW, baht → THB
+    - Leave "" when it equals the ledger's base currency
+    - Fill it whenever the source states a foreign currency in ANY form (name,
+      symbol or code) — don't skip it
+    - e.g. "spent 45 dollars" → "USD"; "Starbucks $6.5" → "USD"; "1200 yen" → "JPY"
   - `tags`: array, can be empty
   - `confidence`: "high" | "medium" | "low"
 """

--- a/src/services/ai/prompts.py
+++ b/src/services/ai/prompts.py
@@ -102,6 +102,8 @@ _TX_DRAFTS_SCHEMA_ZH = """\
   - `account_name`: 从「可用账户」选,选不到用 "";仅 expense/income 有意义
   - `from_account_name` / `to_account_name`: 仅 transfer 用
   - `note`: ≤15 字商家名 / 商品名 / 简短描述
+  - `currency`: 币种 ISO 4217 代码(如 USD / JPY / EUR)。**与账本主币种相同时留 ""**;
+    只有原文/图片明确是外币(如「100 美元」「1200 円」「$45」)才填
   - `tags`: array,可空
   - `confidence`: "high" | "medium" | "low"
     - high: 金额 + 类型 + 时间 都明确从原始内容抠出来
@@ -125,6 +127,9 @@ Each draft has fields:
   - `account_name`: pick from available accounts; "" if no match (for expense/income)
   - `from_account_name` / `to_account_name`: only for transfer
   - `note`: ≤15 chars merchant/item/short description
+  - `currency`: ISO 4217 code (e.g. USD / JPY / EUR). **Leave "" when it equals the
+    ledger's base currency**; only fill it when the source clearly states a foreign
+    currency (e.g. "100 dollars", "1200 yen", "$45")
   - `tags`: array, can be empty
   - `confidence`: "high" | "medium" | "low"
 """
@@ -137,6 +142,7 @@ _PARSE_TX_IMAGE_ZH = """\
 当前时间:{NOW}
 账本可用类目:{CATEGORIES}
 账本可用账户:{ACCOUNTS}
+{CURRENCY_HINT}
 
 {SCHEMA}
 
@@ -156,6 +162,7 @@ transaction visible.
 Current time: {NOW}
 Available categories in this ledger: {CATEGORIES}
 Available accounts in this ledger: {ACCOUNTS}
+{CURRENCY_HINT}
 
 {SCHEMA}
 
@@ -178,6 +185,7 @@ _PARSE_TX_TEXT_ZH = """\
 当前时间:{NOW}
 账本可用类目:{CATEGORIES}
 账本可用账户:{ACCOUNTS}
+{CURRENCY_HINT}
 
 文本:
 {TEXT}
@@ -204,6 +212,7 @@ transactions). Extract every transaction.
 Current time: {NOW}
 Available categories in this ledger: {CATEGORIES}
 Available accounts in this ledger: {ACCOUNTS}
+{CURRENCY_HINT}
 
 Text:
 {TEXT}
@@ -230,16 +239,49 @@ def _format_categories_hint(categories: list[str]) -> str:
     return ", ".join(c for c in categories if c)
 
 
-def _format_accounts_hint(accounts: list[str]) -> str:
+def _format_accounts_hint(
+    accounts: list[tuple[str, str | None]], ledger_currency: str,
+) -> str:
+    """账户清单。**只有币种 ≠ 账本主币种的账户才标注币种** —— 单币种用户看到的
+    字符串与加多币种支持之前逐字相同(零噪声、零回归)。"""
     if not accounts:
         return "(none — leave account_name empty for user to pick)"
-    return ", ".join(a for a in accounts if a)
+    base = (ledger_currency or "").strip().upper()
+    parts: list[str] = []
+    for name, ccy in accounts:
+        if not name:
+            continue
+        code = (ccy or "").strip().upper()
+        parts.append(f"{name}({code})" if code and code != base else name)
+    return ", ".join(parts)
+
+
+def _format_currency_hint(
+    accounts: list[tuple[str, str | None]], ledger_currency: str, *, is_zh: bool,
+) -> str:
+    """币种提示行。账本内只有一种币种时只报主币种(一行,极短);出现外币账户时
+    额外列出可用币种。无论哪种情况都告诉 LLM「也可返回其它 ISO 代码」是多余的
+    —— schema 里已经写了,这里只给上下文。"""
+    base = (ledger_currency or "CNY").strip().upper()
+    others = sorted(
+        {(c or "").strip().upper() for _, c in accounts if (c or "").strip()} - {base, ""}
+    )
+    if is_zh:
+        line = f"账本主币种:{base}"
+        if others:
+            line += f";账本内已有外币账户:{'、'.join(others)}"
+        return line
+    line = f"Ledger base currency: {base}"
+    if others:
+        line += f"; foreign-currency accounts present: {', '.join(others)}"
+    return line
 
 
 def build_parse_tx_image_messages(
     *,
     categories: list[str],
-    accounts: list[str],
+    accounts: list[tuple[str, str | None]],
+    ledger_currency: str = "CNY",
     now: datetime,
     locale: str = "zh",
     image_data_url: str,
@@ -248,7 +290,9 @@ def build_parse_tx_image_messages(
     """B2 截图记账 — 拼 OpenAI vision API messages。
 
     image_data_url: `data:image/jpeg;base64,...` 格式
+    accounts: (名称, 币种) 列表;币种 ≠ 账本主币种时会在 prompt 里标注
     custom_prompt_template: 用户自定义 prompt(从 user.ai_config_json 来),为 None 则用 default
+        —— 自定义模板不含 `{CURRENCY_HINT}` 时 `.format()` 直接忽略该 kwarg,老模板零影响
     """
     is_zh = (locale or "zh").lower().startswith("zh")
     template = custom_prompt_template or (_PARSE_TX_IMAGE_ZH if is_zh else _PARSE_TX_IMAGE_EN)
@@ -256,7 +300,8 @@ def build_parse_tx_image_messages(
     prompt = template.format(
         NOW=now.isoformat(timespec="seconds"),
         CATEGORIES=_format_categories_hint(categories),
-        ACCOUNTS=_format_accounts_hint(accounts),
+        ACCOUNTS=_format_accounts_hint(accounts, ledger_currency),
+        CURRENCY_HINT=_format_currency_hint(accounts, ledger_currency, is_zh=is_zh),
         SCHEMA=schema,
     )
     return [
@@ -274,19 +319,21 @@ def build_parse_tx_text_messages(
     *,
     text: str,
     categories: list[str],
-    accounts: list[str],
+    accounts: list[tuple[str, str | None]],
+    ledger_currency: str = "CNY",
     now: datetime,
     locale: str = "zh",
     custom_prompt_template: str | None = None,
 ) -> list[dict[str, object]]:
-    """B3 文字记账 — 拼 OpenAI chat API messages。"""
+    """B3 文字记账 — 拼 OpenAI chat API messages。参数语义同 [build_parse_tx_image_messages]。"""
     is_zh = (locale or "zh").lower().startswith("zh")
     template = custom_prompt_template or (_PARSE_TX_TEXT_ZH if is_zh else _PARSE_TX_TEXT_EN)
     schema = _TX_DRAFTS_SCHEMA_ZH if is_zh else _TX_DRAFTS_SCHEMA_EN
     prompt = template.format(
         NOW=now.isoformat(timespec="seconds"),
         CATEGORIES=_format_categories_hint(categories),
-        ACCOUNTS=_format_accounts_hint(accounts),
+        ACCOUNTS=_format_accounts_hint(accounts, ledger_currency),
+        CURRENCY_HINT=_format_currency_hint(accounts, ledger_currency, is_zh=is_zh),
         TEXT=text,
         SCHEMA=schema,
     )

--- a/tests/test_ai_parse_currency.py
+++ b/tests/test_ai_parse_currency.py
@@ -1,0 +1,173 @@
+"""智能记账多币种(.docs/multi-currency-ai)— draft 币种解析 + prompt 上下文单测。
+
+单币种用户的**零回归**是本文件最重要的断言:prompt 字符串与账户清单在
+「所有账户都是账本主币种」时必须与加多币种之前逐字相同。
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.routers.ai.parse_tx_image import _norm_currency, _normalize_drafts
+from src.services.ai.prompts import (
+    _format_accounts_hint,
+    _format_currency_hint,
+    build_parse_tx_text_messages,
+)
+
+# ── _norm_currency ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("USD", "USD"),
+        ("usd", "USD"),
+        ("  jpy  ", "JPY"),
+        ("美元", ""),      # server 不做别名映射(§3.2:交给 prompt 直出 ISO)
+        ("US", ""),        # 长度不对
+        ("USDD", ""),
+        ("U$D", ""),
+        ("", ""),
+        (None, ""),
+        (123, ""),         # 非字符串
+    ],
+)
+def test_norm_currency(raw, expected):
+    assert _norm_currency(raw) == expected
+
+
+# ── _normalize_drafts 白名单放行 ──────────────────────────────────────────
+
+
+def test_drafts_currency_passthrough_uppercased():
+    out = _normalize_drafts({"tx_drafts": [{"amount": 45, "currency": "usd"}]})
+    assert out[0]["currency"] == "USD"
+
+
+def test_drafts_currency_invalid_becomes_empty_not_dropped():
+    """非法币种不能让整笔 draft 消失 —— 降级成空串走账本主币种。"""
+    out = _normalize_drafts({"tx_drafts": [{"amount": 45, "currency": "美元"}]})
+    assert len(out) == 1
+    assert out[0]["currency"] == ""
+    assert out[0]["amount"] == 45.0
+
+
+def test_drafts_without_currency_key_defaults_empty():
+    """回归锁:老 LLM 输出(无 currency 键)照常工作。"""
+    out = _normalize_drafts({"tx_drafts": [{"amount": 10, "type": "income"}]})
+    assert out[0]["currency"] == ""
+    assert out[0]["type"] == "income"
+
+
+def test_drafts_currency_does_not_disturb_other_fields():
+    out = _normalize_drafts(
+        {
+            "tx_drafts": [
+                {
+                    "amount": -30,
+                    "type": "expense",
+                    "currency": "JPY",
+                    "category_name": "餐饮",
+                    "account_name": "现金",
+                    "note": "拉面",
+                    "tags": ["旅行"],
+                    "confidence": "high",
+                }
+            ]
+        }
+    )
+    d = out[0]
+    assert (d["amount"], d["type"], d["currency"]) == (30.0, "expense", "JPY")
+    assert (d["category_name"], d["account_name"], d["note"]) == ("餐饮", "现金", "拉面")
+    assert d["tags"] == ["旅行"] and d["confidence"] == "high"
+
+
+# ── 账户清单:单币种零噪声 ────────────────────────────────────────────────
+
+
+def test_accounts_hint_single_currency_has_no_annotation():
+    """单币种账本:输出与加多币种之前逐字相同。"""
+    hint = _format_accounts_hint([("微信", "CNY"), ("支付宝", "CNY")], "CNY")
+    assert hint == "微信, 支付宝"
+
+
+def test_accounts_hint_annotates_only_foreign():
+    hint = _format_accounts_hint([("微信", "CNY"), ("Chase", "USD")], "CNY")
+    assert hint == "微信, Chase(USD)"
+
+
+def test_accounts_hint_handles_missing_currency():
+    hint = _format_accounts_hint([("旧账户", None)], "CNY")
+    assert hint == "旧账户"
+
+
+def test_accounts_hint_empty():
+    assert "none" in _format_accounts_hint([], "CNY")
+
+
+# ── 币种提示行 ────────────────────────────────────────────────────────────
+
+
+def test_currency_hint_single_currency_is_one_short_line():
+    assert _format_currency_hint([("微信", "CNY")], "CNY", is_zh=True) == "账本主币种:CNY"
+
+
+def test_currency_hint_lists_foreign_accounts():
+    hint = _format_currency_hint([("微信", "CNY"), ("Chase", "USD")], "CNY", is_zh=True)
+    assert "USD" in hint and hint.startswith("账本主币种:CNY")
+
+
+def test_currency_hint_en():
+    hint = _format_currency_hint([("Chase", "USD")], "CNY", is_zh=False)
+    assert hint.startswith("Ledger base currency: CNY") and "USD" in hint
+
+
+# ── 自定义 prompt 兼容(A7/A8)────────────────────────────────────────────
+
+
+def test_custom_template_without_currency_placeholder_still_works():
+    """自定义模板不含 {CURRENCY_HINT} 时,.format() 忽略多余 kwarg,不报错。
+
+    注意与 App 的差别(A8):Cloud 的 `{SCHEMA}` 是**独立注入块**、不在用户可编辑
+    的模板正文里,所以自定义模板用户照样拿得到 currency 字段说明 —— 只是少了
+    「账本主币种是什么」这行上下文。App 那边模板是整段替换,才需要 A7 的补丁。
+    """
+    content = build_parse_tx_text_messages(
+        text="午饭 35",
+        categories=["餐饮"],
+        accounts=[("微信", "CNY")],
+        ledger_currency="CNY",
+        now=datetime(2026, 8, 12, tzinfo=timezone.utc),
+        custom_prompt_template="只提取金额:{TEXT}\n{SCHEMA}",
+    )[0]["content"]
+    assert "午饭 35" in content
+    assert "账本主币种:CNY" not in content   # 上下文行没了
+    assert "`currency`" in content            # 但 schema 里的字段说明还在
+
+
+def test_mcp_create_transaction_exposes_currency_param():
+    """回归锁(A9):`write_tools.create_transaction` 一直有 currency 参数,但
+    `@mcp.tool()` 的签名没暴露 → 对 LLM 是死参数,永远传不进来。"""
+    import inspect
+
+    from src.mcp import server as mcp_server
+    from src.mcp.tools import write_tools
+
+    assert "currency" in inspect.signature(write_tools.create_transaction).parameters
+    fn = getattr(mcp_server.create_transaction, "fn", mcp_server.create_transaction)
+    assert "currency" in inspect.signature(fn).parameters
+
+
+def test_default_template_includes_currency_hint_and_schema_field():
+    msgs = build_parse_tx_text_messages(
+        text="在东京吃拉面 1200 日元",
+        categories=["餐饮"],
+        accounts=[("微信", "CNY")],
+        ledger_currency="CNY",
+        now=datetime(2026, 8, 12, tzinfo=timezone.utc),
+    )
+    content = msgs[0]["content"]
+    assert "账本主币种:CNY" in content
+    assert "`currency`" in content

--- a/tests/test_ai_parse_currency.py
+++ b/tests/test_ai_parse_currency.py
@@ -25,7 +25,10 @@ from src.services.ai.prompts import (
         ("USD", "USD"),
         ("usd", "USD"),
         ("  jpy  ", "JPY"),
-        ("美元", ""),      # server 不做别名映射(§3.2:交给 prompt 直出 ISO)
+        ("美元", ""),      # server 不做中文别名映射(§3.2:交给 prompt 直出 ISO)
+        ("$", "USD"),      # 唯一例外:实测 LLM 常把「45 美元」的 currency 回成 "$"
+        (" $ ", "USD"),
+        ("¥", ""),         # 真歧义(CNY/JPY 都写裸 ¥)→ 退回账本主币种
         ("US", ""),        # 长度不对
         ("USDD", ""),
         ("U$D", ""),


### PR DESCRIPTION
承接 #437。AI 记账提取出的交易可以带 ISO 4217 币种,不再一律记成账本主币种。

> **发布顺序**:本 PR **先于 App 部署**(延续交易级多币种的 L10)。App 侧同名 PR 见 TNT-Likely/BeeCount。

## 背景

交易级多币种(v1.6.0 / alembic 0018)已经把 `currency_code` / `native_amount` 两列和折算链路全铺好了,但 **AI 记账这条路径从头到尾没有币种**:prompt 不问、`_normalize_drafts` 白名单不放行、Web 草稿没得改。用户明确说「100 美元」也只会记成 100 元。

**本 PR 零迁移** —— 两列 0018 就有,只是把 AI 侧接上去。

## 改了什么

### 1. Prompt 加币种(`src/services/ai/prompts.py`)

- draft schema 加 `currency` 字段说明(ZH / EN 两份)
- 四个模板加 `{CURRENCY_HINT}` 上下文行
- `_load_ledger_context` 返回账本本位币 + 账户币种

**单币种用户零噪声**:账户清单**只在币种 ≠ 主币种时**才标注币种,所以单币种账本渲染出的 prompt 与本 PR 之前逐字相同(有测试锁)。

### 2. `_normalize_drafts` 放行币种(`src/routers/ai/parse_tx_image.py`,text/image 共用)

这是个**严格白名单**,不放行就等于把 LLM 吐的 currency 丢掉。新增 `_norm_currency`:trim + upper + `^[A-Z]{3}$`,不合法降级成 `""` 而**不是丢弃整笔** —— AI 幻觉出的假币种不该让记账失败。

server 端**有意不做别名映射**(「美元」→USD 之类):server 既没有 App 的 151 币种表,也没有账本上下文做 `$`/`¥` 消歧,统一让 prompt 直出 ISO 更可控。

### 3. Web 草稿币种(`TxDraftList.tsx`)

- 币种选择器**常驻**(非 transfer)。常驻而不是「只在外币时显示」,是因为 AI 可能漏识别 —— 用户必须能在保存前改回来,否则只能存完再逐笔编辑,正是 #437 抱怨的事
- 账户候选按这笔的币种过滤,与 `TransactionsPanel` 单笔表单同构
- 提交前复用现成的 `resolveCurrencyFields` 算 `currency_code` / `native_amount`
- **拉不到汇率阻断保存**(复用 `transactions.error.rateMissing`,零新增 i18n key)。Web 是有人值守的确认式交互,不适用 App 那边无人值守通道的 1:1 降级

汇率只在真沾多币种时才拉(账本有外币账户 / 某笔选了外币),单币种用户不会因此多一次请求。

### 4. MCP 接线

`write_tools.create_transaction` 的 `currency` 参数**早就存在**、`_build_currency_fields` 也会折算,但 `server.py` 的 `@mcp.tool()` 签名没暴露它 → 对 LLM 是**死参数**,永远传不进来。本 PR 接出来,并给批量 `create_transactions` 的 docstring 补上 `currency`(代码本就支持 `raw["currency"]`,纯文档缺口),`parse_and_create_from_text` 透传 draft 币种。

### 5. 顺带修:`_load_ledger_context` 没排除隐藏账户

#240 的 App 端注释白纸黑字写着「隐藏账户不喂给 AI,与手动选择器 / **Web AI 候选**一致」,但 server 侧一直没跟上。不修的话本 PR 新加的「账户(币种)」清单会把隐藏账户连币种一起喂给 AI,反而放大问题。

## 测试

新增 `tests/test_ai_parse_currency.py`(16 例),覆盖 `_norm_currency` 边界、白名单放行、**单币种零回归**、自定义模板兼容、MCP 死参数回归锁。

```
pytest tests   → 444 passed
pnpm build     → ✓
pnpm test      → 58 passed
```

## 设计文档

`.docs/multi-currency-ai/`(gitignore,本地):README(决策 A1-A10)/ 01-design / plan-app / plan-cloud。