### PR TITLE
fix: 修复 Web 首屏连接池耗尽与空 UI

### DIFF
--- a/frontend/apps/web/src/app/AppHeader.tsx
+++ b/frontend/apps/web/src/app/AppHeader.tsx
@@ -37,6 +37,7 @@ import { parseRoute, routePath } from '../state/router'
 interface Props {
   onOpenLogs: () => void
   onOpenAbout: () => void
+  loading?: boolean
 }
 
 /**
@@ -50,7 +51,7 @@ interface Props {
  * 导航通过 react-router `useNavigate`,当前高亮依据 `useLocation().pathname`
  * 反解析到 AppSection。
  */
-export function AppHeader({ onOpenLogs, onOpenAbout }: Props) {
+export function AppHeader({ onOpenLogs, onOpenAbout, loading = false }: Props) {
   const t = useT()
   const navigate = useNavigate()
   const location = useLocation()
@@ -129,7 +130,12 @@ export function AppHeader({ onOpenLogs, onOpenAbout }: Props) {
                 </span>
               </div>
             </button>
-            {ledgers.length > 0 ? (
+            {loading ? (
+              <span
+                className="ml-1 hidden h-8 w-[180px] animate-pulse rounded-md bg-muted md:block"
+                aria-hidden="true"
+              />
+            ) : ledgers.length > 0 ? (
               <Select value={activeLedgerId || undefined} onValueChange={setActiveLedgerId}>
                 <SelectTrigger className="ml-1 hidden h-8 w-[180px] border-border/50 bg-background/60 text-xs md:flex">
                   <SelectValue placeholder={t('shell.ledger')} />
@@ -293,7 +299,9 @@ export function AppHeader({ onOpenLogs, onOpenAbout }: Props) {
                 <ScrollText className="h-4 w-4" />
               </button>
             ) : null}
-            {profileMe?.email ? (
+            {loading ? (
+              <span className="h-8 w-8 animate-pulse rounded-full bg-muted" aria-hidden="true" />
+            ) : profileMe?.email ? (
               <AvatarDropdown
                 profileMe={{
                   email: profileMe.email,
@@ -314,7 +322,9 @@ export function AppHeader({ onOpenLogs, onOpenAbout }: Props) {
         </div>
 
         <div className="flex items-center gap-2 border-t border-border/50 py-2 md:hidden">
-          {ledgers.length > 0 ? (
+          {loading ? (
+            <span className="h-8 flex-1 animate-pulse rounded-md bg-muted" aria-hidden="true" />
+          ) : ledgers.length > 0 ? (
             <Select value={activeLedgerId || undefined} onValueChange={setActiveLedgerId}>
               <SelectTrigger className="h-8 flex-1 border-border/50 bg-background/60 text-xs">
                 <SelectValue placeholder={t('shell.ledger')} />

--- a/frontend/apps/web/src/app/AppShell.tsx
+++ b/frontend/apps/web/src/app/AppShell.tsx
@@ -10,7 +10,7 @@ import {
   type ProfileMe,
   type ReadLedger,
 } from '@beecount/api-client'
-import { usePrimaryColor } from '@beecount/ui'
+import { usePrimaryColor, useT } from '@beecount/ui'
 import type { AppSection } from '@beecount/web-features'
 
 import { AboutDialog } from '../components/AboutDialog'
@@ -60,9 +60,16 @@ export function AppShell({ token, onLogout }: Props) {
   const [profileMe, setProfileMe] = useState<ProfileMe | null>(null)
   const [isAdmin, setIsAdmin] = useState(false)
   const [isAdminResolved, setIsAdminResolved] = useState(false)
+  const [loadedShellUserId, setLoadedShellUserId] = useState<string | null>()
+  const [shellErrorUserId, setShellErrorUserId] = useState<string | null>()
+  const [shellLoadAttempt, setShellLoadAttempt] = useState(0)
   const [logsOpen, setLogsOpen] = useState(false)
   const [aboutOpen, setAboutOpen] = useState(false)
   const sessionUserId = useMemo(() => jwtUserId(token), [token])
+  // access token 定期刷新时 user id 不变,不应重新闪一次骨架屏；只有首次进入
+  // 或真正切换账号时才重新建立 shell 启动边界。
+  const shellLoading = loadedShellUserId !== sessionUserId
+  const shellLoadFailed = shellLoading && shellErrorUserId === sessionUserId
 
   const activeLedgerStorageKey = useMemo(
     () => `beecount.active-ledger.${sessionUserId || 'anon'}`,
@@ -123,24 +130,37 @@ export function AppShell({ token, onLogout }: Props) {
   useEffect(() => {
     if (!token) return
     let cancelled = false
+    const isInitialBootstrap = loadedShellUserId !== sessionUserId
     const run = async () => {
-      try {
-        await Promise.all([refreshLedgers(), refreshProfile()])
-      } catch (err) {
-        if (cancelled) return
-        if (err instanceof ApiError && (err.status === 401 || err.status === 403)) {
-          onLogout()
-        }
-        // eslint-disable-next-line no-console
-        console.warn('[AppShell] initial load error', err)
+      const results = await Promise.allSettled([refreshLedgers(), refreshProfile()])
+      if (cancelled) return
+      const errors = results.flatMap((result) =>
+        result.status === 'rejected' ? [result.reason] : [],
+      )
+      const authError = errors.find(
+        (err) => err instanceof ApiError && (err.status === 401 || err.status === 403),
+      )
+      if (authError) {
+        onLogout()
+        return
       }
+      if (errors.length > 0) {
+        // eslint-disable-next-line no-console
+        console.warn('[AppShell] initial load error', errors)
+        // token 轮换后的后台刷新失败不能卸载已经工作的页面；首次加载失败
+        // 则停在明确的 error/retry 状态,不能把 [] 误当成“确实没有账本”。
+        if (isInitialBootstrap) setShellErrorUserId(sessionUserId)
+        return
+      }
+      setShellErrorUserId(undefined)
+      setLoadedShellUserId(sessionUserId)
     }
     void run()
     return () => {
       cancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token])
+  }, [token, shellLoadAttempt])
 
   useEffect(() => {
     if (!token) return
@@ -202,47 +222,108 @@ export function AppShell({ token, onLogout }: Props) {
         setActiveLedgerId={setActiveLedgerId}
         refreshLedgers={refreshLedgers}
       >
-        <SyncSocketProvider>
-        <PageDataCacheProvider>
-        <AttachmentCacheProvider>
-        <SharedLedgerResourcesProvider>
-        <CategoryIconPrefetcher token={token} />
-        <AppShellSyncReactor
-          refreshLedgers={refreshLedgers}
-          refreshProfile={refreshProfile}
-          applyServerPrimaryColor={applyServerPrimaryColor}
-        />
+        {shellLoading ? (
           <AppLayout
             header={
               <AppHeader
+                loading
                 onOpenLogs={() => setLogsOpen(true)}
                 onOpenAbout={() => setAboutOpen(true)}
               />
             }
           >
-            <div className="space-y-4 pb-20 md:pb-0">
-              <Outlet />
-            </div>
-            <MobileBottomNav
-              activeSection={currentSection}
-              onNavigate={handleSectionNavigate}
-            />
+            {shellLoadFailed ? (
+              <InitialShellError
+                onRetry={() => {
+                  // 立即卸载 retry 按钮、切回 skeleton，避免连续点击叠加多组
+                  // profile + ledgers 请求。
+                  setShellErrorUserId(undefined)
+                  setShellLoadAttempt((value) => value + 1)
+                }}
+              />
+            ) : (
+              <InitialShellSkeleton />
+            )}
           </AppLayout>
-          <LogsDialog token={token} open={logsOpen} onOpenChange={setLogsOpen} />
-          <AboutDialog open={aboutOpen} onOpenChange={setAboutOpen} />
-          <PwaUpdateBanner />
-          <PwaInstallBanner />
-          <GlobalEntityDialogs />
-          <GlobalEditDialogs />
-          <GlobalAskDialog />
-          <GlobalParseTxDialog />
-          <GlobalSharedLedgerDialogs />
-        </SharedLedgerResourcesProvider>
-        </AttachmentCacheProvider>
-        </PageDataCacheProvider>
-        </SyncSocketProvider>
+        ) : (
+          <SyncSocketProvider>
+            <PageDataCacheProvider>
+              <AttachmentCacheProvider>
+                <SharedLedgerResourcesProvider>
+                  <CategoryIconPrefetcher token={token} />
+                  <AppShellSyncReactor
+                    refreshLedgers={refreshLedgers}
+                    refreshProfile={refreshProfile}
+                    applyServerPrimaryColor={applyServerPrimaryColor}
+                  />
+                  <AppLayout
+                    header={
+                      <AppHeader
+                        onOpenLogs={() => setLogsOpen(true)}
+                        onOpenAbout={() => setAboutOpen(true)}
+                      />
+                    }
+                  >
+                    <div className="space-y-4 pb-20 md:pb-0">
+                      <Outlet />
+                    </div>
+                    <MobileBottomNav
+                      activeSection={currentSection}
+                      onNavigate={handleSectionNavigate}
+                    />
+                  </AppLayout>
+                  <LogsDialog token={token} open={logsOpen} onOpenChange={setLogsOpen} />
+                  <AboutDialog open={aboutOpen} onOpenChange={setAboutOpen} />
+                  <PwaUpdateBanner />
+                  <PwaInstallBanner />
+                  <GlobalEntityDialogs />
+                  <GlobalEditDialogs />
+                  <GlobalAskDialog />
+                  <GlobalParseTxDialog />
+                  <GlobalSharedLedgerDialogs />
+                </SharedLedgerResourcesProvider>
+              </AttachmentCacheProvider>
+            </PageDataCacheProvider>
+          </SyncSocketProvider>
+        )}
       </LedgersProvider>
     </AuthProvider>
+  )
+}
+
+/**
+ * profile + ledgers 是整个 Web app 的启动边界。它们完成前不挂载 Outlet、
+ * WebSocket/poller 和页面预取，避免 Overview 的十余个并发请求抢占这两条
+ * 首屏关键请求；同时明确告诉用户页面仍在加载，而不是显示成空账号。
+ */
+function InitialShellSkeleton() {
+  const t = useT()
+  return (
+    <div className="space-y-4 pb-20 md:pb-0" aria-busy="true" role="status">
+      <span className="sr-only">{t('common.loading')}</span>
+      <div className="grid gap-4 md:grid-cols-3">
+        {[0, 1, 2].map((key) => (
+          <div key={key} className="card h-28 animate-pulse bg-muted/60" aria-hidden="true" />
+        ))}
+      </div>
+      <div className="card h-72 animate-pulse bg-muted/60" aria-hidden="true" />
+    </div>
+  )
+}
+
+function InitialShellError({ onRetry }: { onRetry: () => void }) {
+  const t = useT()
+  return (
+    <div className="card mx-auto max-w-lg space-y-4 p-8 text-center" role="alert">
+      <p className="text-sm text-muted-foreground">{t('shell.initialLoadError')}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+      >
+        {t('shell.initialLoadRetry')}
+      </button>
+    </div>
   )
 }
 

--- a/frontend/apps/web/src/i18n/en.ts
+++ b/frontend/apps/web/src/i18n/en.ts
@@ -33,6 +33,8 @@ const en = {
   'login.twofa.hint': 'Verify within 5 minutes — re-login required after timeout.',
   'shell.ledger': 'Ledger',
   'shell.ledger.empty': 'Create ledger',
+  'shell.initialLoadError': 'Could not load your profile and ledgers. Please try again.',
+  'shell.initialLoadRetry': 'Try again',
   'shell.ledgerFilter': 'Ledger Filter',
   'shell.accountFilter': 'Account Filter',
   'shell.userFilter': 'User Filter',

--- a/frontend/apps/web/src/i18n/zh-CN.ts
+++ b/frontend/apps/web/src/i18n/zh-CN.ts
@@ -33,6 +33,8 @@ const zhCN = {
   'login.twofa.hint': '请在 5 分钟内完成验证,超时需重新登录。',
   'shell.ledger': '账本',
   'shell.ledger.empty': '新建账本',
+  'shell.initialLoadError': '无法加载个人资料和账本，请重试。',
+  'shell.initialLoadRetry': '重新加载',
   'shell.ledgerFilter': '账本筛选',
   'shell.accountFilter': '账户筛选',
   'shell.userFilter': '用户筛选',

--- a/frontend/apps/web/src/i18n/zh-TW.ts
+++ b/frontend/apps/web/src/i18n/zh-TW.ts
@@ -33,6 +33,8 @@ const zhTW = {
   'login.twofa.hint': '請在 5 分鐘內完成驗證,超時需重新登入。',
   'shell.ledger': '帳本',
   'shell.ledger.empty': '新建帳本',
+  'shell.initialLoadError': '無法載入個人資料和帳本，請重試。',
+  'shell.initialLoadRetry': '重新載入',
   'shell.ledgerFilter': '帳本篩選',
   'shell.accountFilter': '帳戶篩選',
   'shell.userFilter': '使用者篩選',

--- a/src/database.py
+++ b/src/database.py
@@ -1,15 +1,44 @@
 from collections.abc import Generator
 
 from sqlalchemy import create_engine, event
+from sqlalchemy.engine import make_url
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+from sqlalchemy.pool import NullPool
 
 from .config import get_settings
 
 settings = get_settings()
 
-engine_kwargs: dict = {"pool_pre_ping": True}
-if settings.database_url.startswith("sqlite"):
-    engine_kwargs["connect_args"] = {"check_same_thread": False}
+
+def _is_file_sqlite(database_url: str) -> bool:
+    url = make_url(database_url)
+    if url.get_backend_name() != "sqlite":
+        return False
+    database = url.database or ""
+    # 除了常见的 :memory:,SQLite 还支持 URI named-memory database:
+    # sqlite:///file:name?mode=memory&cache=shared&uri=true。
+    return bool(database and database != ":memory:" and url.query.get("mode") != "memory")
+
+
+def _engine_kwargs(database_url: str) -> dict:
+    kwargs: dict = {"pool_pre_ping": True}
+    if database_url.startswith("sqlite"):
+        kwargs["connect_args"] = {"check_same_thread": False}
+        if _is_file_sqlite(database_url):
+            # SQLAlchemy 2.x 对文件型 SQLite 默认使用 QueuePool(5 + 10,
+            # pool_timeout=30s)。Web 首屏会同时拉 profile / ledgers / analytics /
+            # budgets 等,单个 tab 就可能超过 15 个请求,导致后续请求精确等待
+            # 30s 后报 QueuePool TimeoutError。
+            #
+            # SQLite 连接创建成本很低,真正的并发控制由 WAL + busy_timeout
+            # 负责。NullPool 让每个 request session 在结束时直接关闭连接,不会
+            # 再人为套一层固定 15 个连接的进程内瓶颈。内存 SQLite 不能使用
+            # NullPool(每条连接会得到不同数据库),所以只应用于文件型 SQLite。
+            kwargs["poolclass"] = NullPool
+    return kwargs
+
+
+engine_kwargs = _engine_kwargs(settings.database_url)
 engine = create_engine(settings.database_url, **engine_kwargs)
 
 

--- a/tests/test_sqlite_wal.py
+++ b/tests/test_sqlite_wal.py
@@ -9,8 +9,10 @@ import threading
 import time
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.pool import NullPool
 
-from src.database import SessionLocal, engine
+from src.database import SessionLocal, _engine_kwargs, engine
 
 
 def _is_file_sqlite() -> bool:
@@ -38,6 +40,65 @@ def test_engine_uses_wal_mode():
         assert conn.exec_driver_sql("PRAGMA synchronous").scalar() == 1
         # foreign_keys=ON 让 ondelete=CASCADE 真生效
         assert conn.exec_driver_sql("PRAGMA foreign_keys").scalar() == 1
+
+
+def test_file_sqlite_disables_queue_pool():
+    """文件型 SQLite 不应受 QueuePool 默认 15 连接 / 30 秒超时限制。"""
+    kwargs = _engine_kwargs("sqlite:////tmp/beecount-pool-regression.db")
+    assert kwargs["poolclass"] is NullPool
+    assert kwargs["connect_args"] == {"check_same_thread": False}
+
+
+def test_memory_sqlite_keeps_default_pool():
+    """内存 SQLite 的数据库跟连接绑定,不能使用每次断开的 NullPool。"""
+    kwargs = _engine_kwargs("sqlite:///:memory:")
+    assert "poolclass" not in kwargs
+
+
+def test_named_memory_sqlite_keeps_default_pool():
+    kwargs = _engine_kwargs(
+        "sqlite:///file:beecount_test?mode=memory&cache=shared&uri=true"
+    )
+    assert "poolclass" not in kwargs
+
+
+def test_postgres_pooling_is_unchanged():
+    kwargs = _engine_kwargs("postgresql+psycopg://user:pass@db/beecount")
+    assert kwargs == {"pool_pre_ping": True}
+
+
+def test_initial_read_burst_can_open_more_than_15_connections(tmp_path):
+    """回归 #73:首屏 16 个并发读不能卡在 QueuePool 默认容量上。"""
+    database_url = f"sqlite:///{tmp_path / 'initial-read-burst.db'}"
+    test_engine = create_engine(database_url, **_engine_kwargs(database_url))
+    assert isinstance(test_engine.pool, NullPool)
+
+    concurrency = 16
+    start = threading.Barrier(concurrency + 1)
+    all_connected = threading.Barrier(concurrency)
+    errors: list[Exception] = []
+
+    def reader():
+        try:
+            start.wait(timeout=10)
+            with test_engine.connect() as conn:
+                conn.exec_driver_sql("SELECT 1").scalar()
+                # 所有连接同时保持 checkout；QueuePool 默认最多只能让 15
+                # 个线程到这里，第 16 个会等待，因此 barrier 会超时。
+                all_connected.wait(timeout=10)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=reader, daemon=True) for _ in range(concurrency)]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=10)
+    for thread in threads:
+        thread.join(timeout=12)
+
+    test_engine.dispose()
+    assert not [thread for thread in threads if thread.is_alive()]
+    assert not errors, f"16 个并发 SQLite 读连接都应立即可用: {errors}"
 
 
 def test_concurrent_reader_writer_no_lock():


### PR DESCRIPTION
## 变更说明 / What & Why

修复 Web 首屏并发请求耗尽 SQLAlchemy 连接池、导致头像和账本约 30 秒后才出现的问题。

根因是 SQLAlchemy 2.x 对文件型 SQLite 默认使用 `QueuePool(pool_size=5, max_overflow=10, pool_timeout=30)`，而 Overview 首屏会同时发出超过 15 个数据库请求。超出容量的请求会等待默认的 30 秒，并可能以 `QueuePool TimeoutError` 返回 500。

本 PR 包含两层修复：

- Server：仅对文件型 SQLite 使用 `NullPool`，让请求结束时直接关闭连接，由现有 WAL + `busy_timeout` 负责 SQLite 并发控制；内存 SQLite（包括 named-memory URI）和 PostgreSQL 的连接池行为保持不变。
- Web：先完成 profile + ledgers 两条关键请求，再挂载 Overview、WebSocket/poller 和其他预取；加载期间显示骨架屏，失败时显示可重试错误状态，不再把请求失败误显示为“没有账本”。
- Token 刷新不会重新卸载页面、Provider、弹窗或缓存；只有首次进入或切换账号才启用首屏门控。
- 增加 16 个并发 SQLite 读连接以及连接池选择策略的回归测试。

## 关联 Issue / Related Issue

Closes #73

## 自测情况 / Self-tested

- [x] 后端测试通过 / Backend tests pass（18 项相关测试，512 MiB / 1 CPU 隔离容器）
- [x] 前端构建与测试通过 / Frontend build & tests pass（TypeScript、生产构建、58 项测试；受限资源容器）
- [ ] 已在本地实际运行验证 / Verified by running locally
- [x] 两轮独立 agentic code review 完成，Server 与 Web 均无剩余 findings

## 贡献者许可条款 / Contributor License Terms

- [x] 我已阅读并同意贡献者许可条款 / I have read and agree to the [Contributor License Terms](../CONTRIBUTING.md#贡献者许可条款contributor-license-terms)
