### PR TITLE
ci: 发布通知的变更列表带上提交人

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,9 +216,9 @@ jobs:
 
           PREV_TAG=$(git tag --list --sort=-version:refname | grep -v "^${TAG}$" | head -n1)
           if [ -n "$PREV_TAG" ]; then
-            COMMITS=$(git log --no-merges --pretty=format:"- %s" "$PREV_TAG"..HEAD)
+            COMMITS=$(git log --no-merges --pretty=format:"- %s (%an)" "$PREV_TAG"..HEAD)
           else
-            COMMITS=$(git log --no-merges --pretty=format:"- %s")
+            COMMITS=$(git log --no-merges --pretty=format:"- %s (%an)")
           fi
 
           COMMITS_ESCAPED=$(echo "$COMMITS" | sed 's/\*/\\*/g; s/_/\\_/g; s/\[/\\[/g; s/\]/\\]/g; s/`/\\`/g')


### PR DESCRIPTION
## 背景

App(BeeCount) 的 Telegram 发布通知里每条变更都带提交人（`- feat: xxx (#442) (TNT-Likely)`），但 Cloud 的通知只有标题，看不出是谁的提交。

## 改动

`.github/workflows/release.yml` 的 Send Telegram notification 步骤，`git log` 格式由 `- %s` 改为 `- %s (%an)`，与 App 侧保持一致。两个分支（有 / 无 previous tag）都改。

Release notes 本身早已带提交人（走 compare API 拿 GitHub login），本次只补 Telegram 通知。

## 效果

```
- feat(web): 设置页皮肤下拉支持周年皮肤，自带配色的皮肤同步写回主题色 (#75) (TNT-Likely)
- fix(deps): 锁 mcp<2 —— 2.0.0 删掉 mcp.server.fastmcp 导致 CI 收集失败 (sunxiao)
```

## 验证

本地用真实 git log 跑过上述格式，输出如上。Telegram 的 Markdown 转义只处理 `* _ [ ] \``，`()` 无需转义，沿用原有转义逻辑即可。