### PR TITLE
feat(rag): 支持向量与关键词混合检索

### DIFF
--- a/src/routers/ai/ask.py
+++ b/src/routers/ai/ask.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import AsyncIterator
+from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import StreamingResponse
@@ -91,7 +91,7 @@ async def ask(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={"error_code": "AI_NO_CHAT_PROVIDER", "message": str(exc)},
-        )
+        ) from exc
 
     # 2. 索引可用性检查 — 不可用也直接 503,不进 stream
     docs_idx = get_docs_index(req.locale)
@@ -111,10 +111,10 @@ async def ask(
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail={"error_code": "AI_EMBEDDING_UNAVAILABLE", "message": str(exc)},
-        )
+        ) from exc
 
-    # 4. 检索 top-K
-    retrieved = docs_idx.search(qvec, k=_TOP_K)
+    # 4. 混合检索 top-K — 新索引用 FTS5 + RRF，旧索引自动回退向量检索。
+    retrieved = docs_idx.hybrid_search(query=req.query, query_vector=qvec, k=_TOP_K)
     if not retrieved:
         # 检索 0 命中也走流程,让 LLM 答「文档没找到」(prompt 已约束)
         logger.info("ai.ask top-K empty user=%s query=%s", current_user.id, req.query[:50])

--- a/src/services/ai/docs_index.py
+++ b/src/services/ai/docs_index.py
@@ -10,16 +10,19 @@
 from __future__ import annotations
 
 import logging
+import re
 import sqlite3
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
-from typing import Iterable
 
 import numpy as np
 
-
 logger = logging.getLogger(__name__)
+
+_RRF_OFFSET = 60
+_MIN_TRIGRAM_QUERY_CHARS = 3
 
 
 @dataclass(frozen=True)
@@ -54,6 +57,7 @@ class DocsIndex:
         self.dim: int = 0
         self.embedding_model: str | None = None
         self.build_time: str | None = None
+        self._chunk_positions: dict[int, int] = {}
         self._load()
 
     def _load(self) -> None:
@@ -93,6 +97,7 @@ class DocsIndex:
                 ))
                 vectors.append(np.frombuffer(vec_bytes, dtype=np.float32))
             self.chunks = chunks
+            self._chunk_positions = {chunk.id: position for position, chunk in enumerate(chunks)}
 
             if vectors:
                 m = np.vstack(vectors).astype(np.float32)
@@ -158,6 +163,93 @@ class DocsIndex:
             RetrievedChunk(chunk=self.chunks[i], score=float(sims[i]))
             for i in top_idx
         ]
+
+    def hybrid_search(
+        self,
+        *,
+        query: str,
+        query_vector: Iterable[float],
+        k: int = 4,
+        vector_k: int = 12,
+        keyword_k: int = 12,
+    ) -> list[RetrievedChunk]:
+        """Fuse dense and lexical candidates with reciprocal-rank fusion.
+
+        Old packaged indexes have no ``chunks_fts`` table. They deliberately
+        retain vector-only behavior instead of making a docs update mandatory.
+        """
+        if self.is_empty or k <= 0:
+            return []
+
+        vector_results = self.search(query_vector, k=max(vector_k, 0))
+        keyword_ids = self._keyword_chunk_ids(query, limit=max(keyword_k, 0))
+
+        fused: dict[int, float] = {}
+        for rank, result in enumerate(vector_results, start=1):
+            fused[result.chunk.id] = fused.get(result.chunk.id, 0.0) + 1.0 / (_RRF_OFFSET + rank)
+        for rank, chunk_id in enumerate(keyword_ids, start=1):
+            fused[chunk_id] = fused.get(chunk_id, 0.0) + 1.0 / (_RRF_OFFSET + rank)
+
+        ranked_ids = sorted(fused, key=lambda chunk_id: (-fused[chunk_id], chunk_id))[:k]
+        return [
+            RetrievedChunk(
+                chunk=self.chunks[self._chunk_positions[chunk_id]],
+                score=fused[chunk_id],
+            )
+            for chunk_id in ranked_ids
+        ]
+
+    def _keyword_chunk_ids(self, query: str, *, limit: int) -> list[int]:
+        """Return FTS5 candidates in BM25 order, or none if it is unavailable."""
+        normalized_query = query.strip()
+        if limit <= 0 or len(normalized_query) < _MIN_TRIGRAM_QUERY_CHARS:
+            return []
+
+        # ``trigram`` only matches contiguous text. Turn a natural-language
+        # question into OR-ed trigrams so "如何删除附件" can still retrieve the
+        # section titled "删除附件". Quoting each term keeps FTS operators out
+        # of user-controlled text.
+        chinese_text = re.sub(r"[^\u4e00-\u9fff]", "", normalized_query)
+        tokens = [
+            *([chinese_text] if chinese_text else []),
+            *re.findall(r"[A-Za-z0-9_]+", normalized_query),
+        ]
+        trigrams = [
+            token[offset:offset + _MIN_TRIGRAM_QUERY_CHARS]
+            for token in tokens
+            for offset in range(len(token) - _MIN_TRIGRAM_QUERY_CHARS + 1)
+        ]
+        if not trigrams:
+            return []
+        phrase = " OR ".join(
+            f'"{trigram.replace(chr(34), chr(34) * 2)}"'
+            for trigram in dict.fromkeys(trigrams)
+        )
+        try:
+            conn = sqlite3.connect(self.sqlite_path)
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT rowid
+                    FROM chunks_fts
+                    WHERE chunks_fts MATCH ?
+                    ORDER BY bm25(chunks_fts, 1.0, 5.0, 4.0)
+                    LIMIT ?
+                    """,
+                    (phrase, limit),
+                )
+                return [
+                    int(row[0]) for row in rows
+                    if int(row[0]) in self._chunk_positions
+                ]
+            finally:
+                conn.close()
+        except sqlite3.Error as exc:
+            logger.debug(
+                "docs keyword search unavailable lang=%s path=%s: %s",
+                self.lang, self.sqlite_path, exc,
+            )
+            return []
 
 
 # 单例缓存 ─────────────────────────────────────────────────────────────────

--- a/tests/test_ai_ask.py
+++ b/tests/test_ai_ask.py
@@ -14,20 +14,19 @@ from __future__ import annotations
 import json
 import sqlite3
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from src.database import Base, get_db
 from src.main import app
-from src.models import UserProfile
+from src.models import User, UserProfile
 from src.services.ai import docs_index as docs_index_module
-
 
 # ──────────────────────────────────────────────────────────────────────
 # fixtures
@@ -82,8 +81,6 @@ def _register_and_token(client: TestClient, email: str = "ai@test.com") -> tuple
     )
     token = r.json()["access_token"]
     # 查 DB 拿 user_id
-    from sqlalchemy import select
-    from src.models import User
     db = next(app.dependency_overrides[get_db]())
     try:
         user = db.scalar(select(User).where(User.email == email))
@@ -317,6 +314,47 @@ def test_ask_happy_path_streams_chunks_and_sources(fake_index_dir, monkeypatch):
         sources = [e for e in events if e["type"] == "sources"][0]["items"]
         assert len(sources) == 3
         assert all(s["url"].startswith("https://count.beejz.com/docs/") for s in sources)
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_ask_uses_hybrid_retrieval(monkeypatch):
+    """The question text must reach the hybrid retriever with its embedding."""
+    calls: list[tuple[str, list[float], int]] = []
+
+    class HybridOnlyIndex:
+        is_empty = False
+
+        def hybrid_search(self, *, query, query_vector, k):
+            calls.append((query, query_vector, k))
+            return []
+
+    async def fake_embed(query):
+        assert query == "删除附件"
+        return [0.25, 0.75]
+
+    async def fake_stream(*, config, messages, timeout=30.0):
+        yield "文档中没有更多说明。"
+
+    monkeypatch.setattr("src.routers.ai.ask.get_docs_index", lambda locale: HybridOnlyIndex())
+    monkeypatch.setattr("src.routers.ai.ask.embed_query", fake_embed)
+    monkeypatch.setattr("src.routers.ai.ask.stream_chat_completion", fake_stream)
+    monkeypatch.setattr(
+        "src.routers.ai.ask.resolve_chat_provider",
+        lambda user, profile: SimpleNamespace(provider_id="test-provider"),
+    )
+
+    client = _make_client()
+    try:
+        token, _ = _register_and_token(client)
+        response = client.post(
+            "/api/v1/ai/ask",
+            json={"query": "删除附件", "locale": "zh"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 200, response.text
+        assert calls == [("删除附件", [0.25, 0.75], 4)]
     finally:
         app.dependency_overrides.clear()
 

--- a/tests/test_docs_hybrid_search.py
+++ b/tests/test_docs_hybrid_search.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+
+from src.services.ai.docs_index import DocsIndex
+
+
+def _write_hybrid_index(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE chunks (
+                id INTEGER PRIMARY KEY,
+                content TEXT NOT NULL,
+                doc_path TEXT NOT NULL,
+                doc_title TEXT,
+                section TEXT,
+                url TEXT,
+                vector BLOB NOT NULL
+            );
+            CREATE VIRTUAL TABLE chunks_fts USING fts5(
+                content, doc_title, section, tokenize='trigram'
+            );
+            CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+            """
+        )
+        rows = [
+            (
+                1,
+                "# 交易记录\\n\\n编辑一笔交易的通用说明。",
+                "record/edit.md",
+                "交易记录",
+                "编辑交易",
+                [1.0, 0.0],
+            ),
+            (
+                2,
+                "# 交易附件\\n\\n长按要删除的附件图片并确认删除。",
+                "record/attachment.md",
+                "交易附件",
+                "删除附件",
+                [0.0, 1.0],
+            ),
+        ]
+        for chunk_id, content, doc_path, title, section, vector in rows:
+            conn.execute(
+                "INSERT INTO chunks VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    chunk_id,
+                    content,
+                    doc_path,
+                    title,
+                    section,
+                    f"https://example.test/{chunk_id}",
+                    np.asarray(vector, dtype=np.float32).tobytes(),
+                ),
+            )
+            conn.execute(
+                "INSERT INTO chunks_fts(rowid, content, doc_title, section) VALUES (?, ?, ?, ?)",
+                (chunk_id, content, title, section),
+            )
+        conn.execute("INSERT INTO meta VALUES ('dim', '2')")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_hybrid_search_promotes_exact_section_keyword_over_vector_only_match(tmp_path):
+    path = tmp_path / "docs-index.zh.sqlite"
+    _write_hybrid_index(path)
+    index = DocsIndex(lang="zh", sqlite_path=path)
+
+    result = index.hybrid_search(
+        query="删除附件",
+        query_vector=[1.0, 0.0],
+        k=1,
+        vector_k=2,
+        keyword_k=2,
+    )
+
+    assert [item.chunk.id for item in result] == [2]
+
+
+def test_hybrid_search_matches_keyword_inside_a_natural_language_question(tmp_path):
+    path = tmp_path / "docs-index.zh.sqlite"
+    _write_hybrid_index(path)
+    index = DocsIndex(lang="zh", sqlite_path=path)
+
+    result = index.hybrid_search(
+        query="如何删除附件",
+        query_vector=[1.0, 0.0],
+        k=1,
+        vector_k=2,
+        keyword_k=2,
+    )
+
+    assert [item.chunk.id for item in result] == [2]
+
+
+def test_hybrid_search_joins_chinese_keywords_split_by_punctuation(tmp_path):
+    path = tmp_path / "docs-index.zh.sqlite"
+    _write_hybrid_index(path)
+    index = DocsIndex(lang="zh", sqlite_path=path)
+
+    result = index.hybrid_search(
+        query="如何删除，附件？",
+        query_vector=[1.0, 0.0],
+        k=1,
+        vector_k=2,
+        keyword_k=2,
+    )
+
+    assert [item.chunk.id for item in result] == [2]


### PR DESCRIPTION
## 改动内容

- 文档问答从纯向量 Top-K 升级为向量召回与 FTS5 关键词召回的 RRF 融合。
- 关键词召回对标题、章节给予更高 BM25 权重，并能处理中文问句中夹杂的标点。
- 旧版索引缺少 FTS 表时自动保持纯向量检索，避免运行中断。
- 补充 RRF 排序、自然语言关键词、标点边界及接口接入测试。

## 验证

- `pytest tests -q`
- `ruff check src/services/ai/docs_index.py src/routers/ai/ask.py tests/test_docs_hybrid_search.py tests/test_ai_ask.py`

## 依赖

依赖 BeeCount-Website 的关键词索引 PR：https://github.com/TNT-Likely/BeeCount-Website/pull/7 。该 PR 合并后 CI 会重建并发布带 FTS5 的索引；在此之前本改动会安全回退到纯向量检索。
