### PR TITLE
refactor: 为本地化名称添加语言和文本方向信息

### DIFF
--- a/frontend/apps/web/public/manifest.webmanifest
+++ b/frontend/apps/web/public/manifest.webmanifest
@@ -1,20 +1,97 @@
 {
   "id": "/?source=pwa",
   "name": "蜜蜂记账",
+  "name_localized": {
+    "zh-TW": "蜜蜂記帳",
+    "ko": "꿀벌 가계부",
+    "en": "BeeCount",
+    "fa": "حساب زنبور"
+  },
   "short_name": "蜜蜂记账",
+  "short_name_localized": {
+    "zh-TW": "蜜蜂記帳",
+    "ko": "꿀벌 가계부",
+    "en": "BeeCount",
+    "fa": "حساب زنبور"
+  },
   "description": "自部署的个人记账云 · 移动端 / 网页端实时同步",
+  "description_localized": {
+    "zh-TW": "自部署的個人記帳雲 · 行動版 / 網頁版即時同步",
+    "ko": "직접 배포하는 개인 가계부 클라우드 · 모바일 / 웹 실시간 동기화",
+    "en": "Self-hosted personal bookkeeping cloud · Real-time sync between mobile / web",
+    "fa": "ابر حساب‌وکتاب شخصیِ خودمیزبان · همگام‌سازی لحظه‌ای موبایل / وب"
+  },
   "lang": "zh-CN",
   "dir": "ltr",
   "start_url": "/?source=pwa",
   "scope": "/",
   "display": "standalone",
-  "display_override": ["window-controls-overlay", "standalone", "minimal-ui", "browser"],
+  "display_override": [
+    "window-controls-overlay",
+    "standalone",
+    "minimal-ui",
+    "browser"
+  ],
   "orientation": "any",
   "background_color": "#000000",
   "theme_color": "#F59E0B",
-  "categories": ["finance", "productivity", "utilities"],
+  "categories": [
+    "finance",
+    "productivity",
+    "utilities"
+  ],
+  "keywords": [
+    "钱",
+    "账户",
+    "余额",
+    "交易",
+    "付款",
+    "收入",
+    "支出",
+    "转账",
+    "存款",
+    "取款",
+    "錢",
+    "帳戶",
+    "餘額",
+    "轉帳",
+    "提款",
+    "돈",
+    "계좌",
+    "잔액",
+    "거래",
+    "결제",
+    "수입",
+    "지출",
+    "이체",
+    "입금",
+    "출금",
+    "money",
+    "account",
+    "balance",
+    "transaction",
+    "payment",
+    "income",
+    "expense",
+    "transfer",
+    "deposit",
+    "withdrawal",
+    "پول",
+    "حساب",
+    "موجودی",
+    "تراکنش",
+    "پرداخت",
+    "درآمد",
+    "هزینه",
+    "انتقال",
+    "واریز",
+    "برداشت"
+  ],
   "launch_handler": {
-    "client_mode": ["focus-existing", "auto"]
+    "client_mode": [
+      "focus-existing",
+      "auto"
+    ]
   },
   "icons": [
     {
@@ -51,8 +128,26 @@
   "shortcuts": [
     {
       "name": "记一笔",
+      "name_localized": {
+        "zh-TW": "記一筆",
+        "ko": "기록하기",
+        "en": "Add Transaction",
+        "fa": "ثبت تراکنش"
+      },
       "short_name": "记账",
+      "short_name_localized": {
+        "zh-TW": "記帳",
+        "ko": "가계부",
+        "en": "Bookkeeping",
+        "fa": "حساب‌وکتاب"
+      },
       "description": "快速新建一笔交易",
+      "description_localized": {
+        "zh-TW": "快速新增一筆交易",
+        "ko": "빠르게 거래 내역을 추가하세요",
+        "en": "Quickly add a transaction",
+        "fa": "به‌سرعت یک تراکنش جدید ثبت کنید"
+      },
       "url": "/app/transactions?action=quick-add&source=shortcut",
       "icons": [
         {
@@ -64,8 +159,26 @@
     },
     {
       "name": "今日账单",
+      "name_localized": {
+        "zh-TW": "今日帳單",
+        "ko": "오늘의 내역",
+        "en": "Today's Transactions",
+        "fa": "تراکنش‌های امروز"
+      },
       "short_name": "今日",
+      "short_name_localized": {
+        "zh-TW": "今日",
+        "ko": "오늘",
+        "en": "Today",
+        "fa": "امروز"
+      },
       "description": "查看今天的所有交易",
+      "description_localized": {
+        "zh-TW": "查看今天的所有交易",
+        "ko": "오늘의 모든 거래 내역을 확인하세요",
+        "en": "View all transactions from today",
+        "fa": "همه‌ی تراکنش‌های امروز را مشاهده کنید"
+      },
       "url": "/app/transactions?range=today&source=shortcut",
       "icons": [
         {
@@ -77,8 +190,26 @@
     },
     {
       "name": "本月预算",
+      "name_localized": {
+        "zh-TW": "本月預算",
+        "ko": "이번 달 예산",
+        "en": "This Month's Budget",
+        "fa": "بودجه‌ی این ماه"
+      },
       "short_name": "预算",
+      "short_name_localized": {
+        "zh-TW": "預算",
+        "ko": "예산",
+        "en": "Budget",
+        "fa": "بودجه"
+      },
       "description": "查看本月预算执行情况",
+      "description_localized": {
+        "zh-TW": "查看本月預算執行情況",
+        "ko": "이번 달 예산 현황을 확인하세요",
+        "en": "View this month's budget status",
+        "fa": "وضعیت بودجه‌ی این ماه را مشاهده کنید"
+      },
       "url": "/app/budgets?source=shortcut",
       "icons": [
         {
@@ -100,7 +231,13 @@
       "files": [
         {
           "name": "files",
-          "accept": ["image/*", "text/csv", ".csv", ".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"]
+          "accept": [
+            "image/*",
+            "text/csv",
+            ".csv",
+            ".xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+          ]
         }
       ]
     }
@@ -109,9 +246,15 @@
     {
       "action": "/app/share-incoming?source=file-handler",
       "accept": {
-        "text/csv": [".csv"],
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [".xlsx"],
-        "application/vnd.ms-excel": [".xls"]
+        "text/csv": [
+          ".csv"
+        ],
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [
+          ".xlsx"
+        ],
+        "application/vnd.ms-excel": [
+          ".xls"
+        ]
       },
       "icons": [
         {

--- a/frontend/apps/web/public/manifest.webmanifest
+++ b/frontend/apps/web/public/manifest.webmanifest
@@ -58,33 +58,6 @@
     "productivity",
     "utilities"
   ],
-  "keywords": [
-    "钱",
-    "账户",
-    "余额",
-    "交易",
-    "付款",
-    "收入",
-    "支出",
-    "转账",
-    "存款",
-    "取款",
-    "錢",
-    "帳戶",
-    "餘額",
-    "轉帳",
-    "提款",
-    "money",
-    "account",
-    "balance",
-    "transaction",
-    "payment",
-    "income",
-    "expense",
-    "transfer",
-    "deposit",
-    "withdrawal"
-  ],
   "launch_handler": {
     "client_mode": [
       "focus-existing",

--- a/frontend/apps/web/public/manifest.webmanifest
+++ b/frontend/apps/web/public/manifest.webmanifest
@@ -2,24 +2,42 @@
   "id": "/?source=pwa",
   "name": "蜜蜂记账",
   "name_localized": {
-    "zh-TW": "蜜蜂記帳",
-    "ko": "꿀벌 가계부",
-    "en": "BeeCount",
-    "fa": "حساب زنبور"
+    "zh-TW": {
+      "value": "蜜蜂記帳",
+      "lang": "zh-TW",
+      "dir": "ltr"
+    },
+    "en": {
+      "value": "BeeCount",
+      "lang": "en-US",
+      "dir": "ltr"
+    }
   },
   "short_name": "蜜蜂记账",
   "short_name_localized": {
-    "zh-TW": "蜜蜂記帳",
-    "ko": "꿀벌 가계부",
-    "en": "BeeCount",
-    "fa": "حساب زنبور"
+    "zh-TW": {
+      "value": "蜜蜂記帳",
+      "lang": "zh-TW",
+      "dir": "ltr"
+    },
+    "en": {
+      "value": "BeeCount",
+      "lang": "en-US",
+      "dir": "ltr"
+    }
   },
   "description": "自部署的个人记账云 · 移动端 / 网页端实时同步",
   "description_localized": {
-    "zh-TW": "自部署的個人記帳雲 · 行動版 / 網頁版即時同步",
-    "ko": "직접 배포하는 개인 가계부 클라우드 · 모바일 / 웹 실시간 동기화",
-    "en": "Self-hosted personal bookkeeping cloud · Real-time sync between mobile / web",
-    "fa": "ابر حساب‌وکتاب شخصیِ خودمیزبان · همگام‌سازی لحظه‌ای موبایل / وب"
+    "zh-TW": {
+      "value": "自部署的個人記帳雲 · 行動版 / 網頁版即時同步",
+      "lang": "zh-TW",
+      "dir": "ltr"
+    },
+    "en": {
+      "value": "Self-hosted personal bookkeeping cloud · Real-time sync between mobile / web",
+      "lang": "en-US",
+      "dir": "ltr"
+    }
   },
   "lang": "zh-CN",
   "dir": "ltr",
@@ -56,16 +74,6 @@
     "餘額",
     "轉帳",
     "提款",
-    "돈",
-    "계좌",
-    "잔액",
-    "거래",
-    "결제",
-    "수입",
-    "지출",
-    "이체",
-    "입금",
-    "출금",
     "money",
     "account",
     "balance",
@@ -75,17 +83,7 @@
     "expense",
     "transfer",
     "deposit",
-    "withdrawal",
-    "پول",
-    "حساب",
-    "موجودی",
-    "تراکنش",
-    "پرداخت",
-    "درآمد",
-    "هزینه",
-    "انتقال",
-    "واریز",
-    "برداشت"
+    "withdrawal"
   ],
   "launch_handler": {
     "client_mode": [
@@ -129,24 +127,42 @@
     {
       "name": "记一笔",
       "name_localized": {
-        "zh-TW": "記一筆",
-        "ko": "기록하기",
-        "en": "Add Transaction",
-        "fa": "ثبت تراکنش"
+        "zh-TW": {
+          "value": "記一筆",
+          "lang": "zh-TW",
+          "dir": "ltr"
+        },
+        "en": {
+          "value": "Add Transaction",
+          "lang": "en-US",
+          "dir": "ltr"
+        }
       },
       "short_name": "记账",
       "short_name_localized": {
-        "zh-TW": "記帳",
-        "ko": "가계부",
-        "en": "Bookkeeping",
-        "fa": "حساب‌وکتاب"
+        "zh-TW": {
+          "value": "記帳",
+          "lang": "zh-TW",
+          "dir": "ltr"
+        },
+        "en": {
+          "value": "Bookkeeping",
+          "lang": "en-US",
+          "dir": "ltr"
+        }
       },
       "description": "快速新建一笔交易",
       "description_localized": {
-        "zh-TW": "快速新增一筆交易",
-        "ko": "빠르게 거래 내역을 추가하세요",
-        "en": "Quickly add a transaction",
-        "fa": "به‌سرعت یک تراکنش جدید ثبت کنید"
+        "zh-TW": {
+          "value": "快速新增一筆交易",
+          "lang": "zh-TW",
+          "dir": "ltr"
+        },
+        "en": {
+          "value": "Quickly add a transaction",
+          "lang": "en-US",
+          "dir": "ltr"
+        }
       },
       "url": "/app/transactions?action=quick-add&source=shortcut",
       "icons": [
@@ -160,24 +176,42 @@
     {
       "name": "今日账单",
       "name_localized": {
-        "zh-TW": "今日帳單",
-        "ko": "오늘의 내역",
-        "en": "Today's Transactions",
-        "fa": "تراکنش‌های امروز"
+        "zh-TW": {
+          "value": "今日帳單",
+          "lang": "zh-TW",
+          "dir": "ltr"
+        },
+        "en": {
+          "value": "Today's Transactions",
+          "lang": "en-US",
+          "dir": "ltr"
+        }
       },
       "short_name": "今日",
       "short_name_localized": {
-        "zh-TW": "今日",
-        "ko": "오늘",
-        "en": "Today",
-        "fa": "امروز"
+        "zh-TW": {
+          "value": "今日",
+          "lang": "zh-TW",
+          "dir": "ltr"
+        },
+        "en": {
+          "value": "Today",
+          "lang": "en-US",
+          "dir": "ltr"
+        }
       },
       "description": "查看今天的所有交易",
       "description_localized": {
-        "zh-TW": "查看今天的所有交易",
-        "ko": "오늘의 모든 거래 내역을 확인하세요",
-        "en": "View all transactions from today",
-        "fa": "همه‌ی تراکنش‌های امروز را مشاهده کنید"
+        "zh-TW": {
+          "value": "查看今天的所有交易",
+          "lang": "zh-TW",
+          "dir": "ltr"
+        },
+        "en": {
+          "value": "View all transactions from today",
+          "lang": "en-US",
+          "dir": "ltr"
+        }
       },
       "url": "/app/transactions?range=today&source=shortcut",
       "icons": [
@@ -191,24 +225,42 @@
     {
       "name": "本月预算",
       "name_localized": {
-        "zh-TW": "本月預算",
-        "ko": "이번 달 예산",
-        "en": "This Month's Budget",
-        "fa": "بودجه‌ی این ماه"
+        "zh-TW": {
+          "value": "本月預算",
+          "lang": "zh-TW",
+          "dir": "ltr"
+        },
+        "en": {
+          "value": "This Month's Budget",
+          "lang": "en-US",
+          "dir": "ltr"
+        }
       },
       "short_name": "预算",
       "short_name_localized": {
-        "zh-TW": "預算",
-        "ko": "예산",
-        "en": "Budget",
-        "fa": "بودجه"
+        "zh-TW": {
+          "value": "預算",
+          "lang": "zh-TW",
+          "dir": "ltr"
+        },
+        "en": {
+          "value": "Budget",
+          "lang": "en-US",
+          "dir": "ltr"
+        }
       },
       "description": "查看本月预算执行情况",
       "description_localized": {
-        "zh-TW": "查看本月預算執行情況",
-        "ko": "이번 달 예산 현황을 확인하세요",
-        "en": "View this month's budget status",
-        "fa": "وضعیت بودجه‌ی این ماه را مشاهده کنید"
+        "zh-TW": {
+          "value": "查看本月預算執行情況",
+          "lang": "zh-TW",
+          "dir": "ltr"
+        },
+        "en": {
+          "value": "View this month's budget status",
+          "lang": "en-US",
+          "dir": "ltr"
+        }
       },
       "url": "/app/budgets?source=shortcut",
       "icons": [

--- a/frontend/apps/web/public/sw.js
+++ b/frontend/apps/web/public/sw.js
@@ -12,7 +12,7 @@
  * API 请求（/api/*）绕过 SW —— 直接去网络，避免缓存 token/敏感数据。
  */
 
-const CACHE_VERSION = 'beecount-web-v2'
+const CACHE_VERSION = 'beecount-web-v3'
 const SHARE_CACHE = 'beecount-share-target-v1'
 const PRECACHE = ['/', '/index.html', '/manifest.webmanifest', '/branding/logo.svg']
 


### PR DESCRIPTION
## 变更说明 / What & Why

* 使用 manifest 占位符来选择本地化的应用名称资源。
* 添加繁体中文、英文和应用名称资源。
* 保留简体中文作为默认回退语言。

## 关联 Issue / Related Issue

**修复 Web 应用中的问题 https://github.com/TNT-Likely/BeeCount/issues/472**

## 自测情况 / Self-tested

- [x] 后端测试通过 / Backend tests pass（`pytest`）
- [x] 前端构建与测试通过 / Frontend build & tests pass（`pnpm build` / `pnpm test`，如涉及前端 / if frontend is touched）
- [x] 已在本地实际运行验证 / Verified by running locally

## 贡献者许可条款 / Contributor License Terms

- [x] 我已阅读并同意贡献者许可条款 / I have read and agree to the [Contributor License Terms](../CONTRIBUTING.md#贡献者许可条款contributor-license-terms)
